### PR TITLE
DOCS-12292 - Release version 2.3.2

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,8 @@ extensions = [
     'mongodb',
     'directives',
     'intermanual',
-    'fasthtml'
+    'fasthtml',
+    'source_constants'
 ]
 
 templates_path = ['.templates']
@@ -58,6 +59,12 @@ rst_epilog = '\n'.join([
 extlinks = {
     'manual': ('https://docs.mongodb.com/manual%s', ''),
     'mongo-spark': ('https://github.com/mongodb/mongo-spark%s', ''),
+}
+
+source_constants = {
+    'current-version': '2.3.2',
+    'spark-core-version': '2.3.2',
+    'spark-sql-version': '2.3.2'
 }
 
 intersphinx_mapping = {}

--- a/source/includes/extracts-command-line.yaml
+++ b/source/includes/extracts-command-line.yaml
@@ -39,7 +39,7 @@ content: |
 
       ./bin/spark-shell --conf "spark.mongodb.input.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
                         --conf "spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection" \
-                        --packages org.mongodb.spark:mongo-spark-connector_2.11:2.3.1
+                        --packages org.mongodb.spark:mongo-spark-connector_2.11:{+current-version+}
  
    .. include:: /includes/extracts/list-configuration-explanation.rst
 
@@ -56,7 +56,7 @@ content: |
 
       ./bin/pyspark --conf "spark.mongodb.input.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
                     --conf "spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection" \
-                    --packages org.mongodb.spark:mongo-spark-connector_2.11:2.3.1
+                    --packages org.mongodb.spark:mongo-spark-connector_2.11:{+current-version+}
  
    .. include:: /includes/extracts/list-configuration-explanation.rst
 
@@ -73,7 +73,7 @@ content: |
 
       ./bin/sparkR  --conf "spark.mongodb.input.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
                     --conf "spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection" \
-                    --packages org.mongodb.spark:mongo-spark-connector_2.11:2.3.1
+                    --packages org.mongodb.spark:mongo-spark-connector_2.11:{+current-version+}
 
    .. include:: /includes/extracts/list-configuration-explanation.rst
 ...

--- a/source/includes/list-prerequisites.rst
+++ b/source/includes/list-prerequisites.rst
@@ -6,4 +6,4 @@
 
 - Spark 2.3.x.
 
-- Scala 2.11.x  
+- Scala 2.11.x.

--- a/source/index.txt
+++ b/source/index.txt
@@ -24,15 +24,19 @@ versions of Apache Spark and MongoDB:
      - Spark Version
      - MongoDB Version
 
-   * - **2.3.1**
+   * - 2.4.0
+     - 2.4.x
+     - 2.6 or later
+
+   * - **{+current-version+}**
      - **2.3.x**
      - **2.6 or later**
 
-   * - 2.2.5
+   * - 2.2.6
      - 2.2.x
      - 2.6 or later
 
-   * - 2.1.4
+   * - 2.1.5
      - 2.1.x
      - 2.6 or later
 
@@ -49,32 +53,37 @@ versions of Apache Spark and MongoDB:
 
 .. admonition:: Announcements
 
-   - **Oct 08, 2018**, `MongoDB Connector for Spark versions v2.3.1, v2.2.5 and v2.1.4
+   - **Dec 07, 2018**, `MongoDB Connector for Spark versions v2.4.0,
+     v2.3.2, v2.2.6, and v2.1.5
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **July 30, 2018**, `MongoDB Connector for Spark versions v2.3.0, v2.2.4 and v2.1.3
+   - **Oct 08, 2018**, `MongoDB Connector for Spark versions v2.3.1,
+     v2.2.5, and v2.1.4
+     <https://www.mongodb.com/products/spark-connector>`_ Released.
+
+   - **July 30, 2018**, `MongoDB Connector for Spark versions v2.3.0,
+     v2.2.4, and v2.1.3
      <https://www.mongodb.com/products/spark-connector>`_ Released.
    
-   - **June 19, 2018**, `MongoDB Connector for Spark versions v2.2.3 and v2.1.2
+   - **June 19, 2018**, `MongoDB Connector for Spark versions v2.2.3 and
+     v2.1.2
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **April 18, 2018**, `MongoDB Connector for Spark versions v2.2.2
+   - **April 18, 2018**, `MongoDB Connector for Spark version v2.2.2
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **Oct 31, 2017**, `MongoDB Connector for Spark versions v2.2.1 and v2.2.1
+   - **Oct 31, 2017**, `MongoDB Connector for Spark version v2.2.1
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **July 13, 2017**, `MongoDB Connector for Spark v2.2.0
+   - **July 13, 2017**, `MongoDB Connector for Spark version v2.2.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **July 12, 2017**, `MongoDB Connector for Spark versions v2.2.0 and v2.1.0
+   - **July 12, 2017**, `MongoDB Connector for Spark versions v2.2.0 and
+     v2.1.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
    - **November 1, 2016**, `MongoDB Connector for Spark v2.0.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
-
-   - **Online course**. `Getting Started with Spark and MongoDB
-     <https://university.mongodb.com/courses/M233/about?jmp=docs>`_.
 
 .. class:: hidden
 
@@ -88,4 +97,4 @@ versions of Apache Spark and MongoDB:
       r-api
       faq
       release-notes
-      API Docs <https://www.javadoc.io/doc/org.mongodb.spark/mongo-spark-connector_2.11/2.3.1>
+      API Docs <https://www.javadoc.io/doc/org.mongodb.spark/mongo-spark-connector_2.11/{+current-version+}>

--- a/source/java-api.txt
+++ b/source/java-api.txt
@@ -15,7 +15,7 @@ Prerequisites
 
 .. include:: /includes/list-prerequisites.rst
 
-- Java 6 or later.
+- Java 8 or later.
 
 Getting Started
 ---------------
@@ -33,17 +33,17 @@ The following excerpt is from a Maven ``pom.xml`` file:
      <dependency>
        <groupId>org.mongodb.spark</groupId>
        <artifactId>mongo-spark-connector_2.11</artifactId>
-       <version>2.3.1</version>
+       <version>{+current-version+}</version>
      </dependency>
      <dependency>
        <groupId>org.apache.spark</groupId>
        <artifactId>spark-core_2.11</artifactId>
-       <version>2.3.2</version>
+       <version>{+spark-core-version+}</version>
      </dependency>
      <dependency>
        <groupId>org.apache.spark</groupId>
        <artifactId>spark-sql_2.11</artifactId>
-       <version>2.3.2</version>
+       <version>{+spark-sql-version+}</version>
      </dependency>
    </dependencies>
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -4,6 +4,14 @@ Release Notes
 
 .. default-domain:: mongodb
 
+MongoDB Connector for Spark `2.3.2`_
+------------------------------------
+
+*Released on December 7, 2018*
+
+- Ensure ``WriteConfig.ordered`` is applied to write operations.
+- Fixed ``MongoSpark.toDF()`` to use the provided ``MongoConnector``.
+
 MongoDB Connector for Spark `2.3.1`_
 ------------------------------------
 
@@ -59,98 +67,6 @@ MongoDB Connector for Spark `2.3.0`_
 - `SPARK-199 <https://jira.mongodb.org/browse/SPARK-199>`_ ``Row`` to
   ``Document`` optimization.
 
-MongoDB Connector for Spark `2.2.3`_
-------------------------------------
-
-*Released on June 19, 2018*
-
-- `SPARK-187 <https://jira.mongodb.org/browse/SPARK-187>`_ Fixed
-  inferring decimal values with larger scales than precisions.
-
-MongoDB Connector for Spark `2.2.2`_
-------------------------------------
-
-*Released on April 18, 2018*
-
-- `SPARK-150 <https://jira.mongodb.org/browse/SPARK-150>`_ Fixed
-  ``MongoShardedPartitioner`` to work with compound shard keys.
-
-- `SPARK-147 <https://jira.mongodb.org/browse/SPARK-147>`_ Fixed
-  writing Datasets for compound shard keys, see `WriteConfig#shardKey <https://static.javadoc.io/org.mongodb.spark/mongo-spark-connector_2.11/2.1.3/index.html#com.mongodb.spark.config.WriteConfig@shardKey:Option[String]>`_.
-
-- `SPARK-157 <https://jira.mongodb.org/browse/SPARK-157>`_ Fix
-  ``MongoPaginateByCountPartitioner`` single item with query exception.
-
-- `SPARK-158 <https://jira.mongodb.org/browse/SPARK-158>`_ Fix null
-  handling for String columns.
-
-- `SPARK-173 <https://jira.mongodb.org/browse/SPARK-173>`_ Improved
-  error messages for cursor not found exceptions.
-
-MongoDB Connector for Spark `2.2.1`_
-------------------------------------
-
-*Released on October 31, 2017*
-
-- `SPARK-151 <https://jira.mongodb.org/browse/SPARK-151>`_ Fix
-  ``MongoSamplePartitioner`` $match range bug.
-
-MongoDB Connector for Spark `2.2.0`_
-------------------------------------
-
-*Released on July 13, 2017*
-
-- `SPARK-127 <https://jira.mongodb.org/browse/SPARK-127>`_ Fix Scala
-  2.10 compiler error for Java bean type inference.
-
-- `SPARK-126 <https://jira.mongodb.org/browse/SPARK-126>`_ Support
-  Spark 2.2.0. Updated Spark dependency to 2.2.0.
-
-MongoDB Connector for Spark `2.1.0`_
-------------------------------------
-
-*Released on July 12, 2017*
-
-- `SPARK-125 <https://jira.mongodb.org/browse/SPARK-125>`_ Updated
-  Spark dependency to 2.1.1.
-
-- `SPARK-124 <https://jira.mongodb.org/browse/SPARK-124>`_ Made the
-  maximum batch size when performing bulk updates / inserts
-  configurable.
-
-- `SPARK-106 <https://jira.mongodb.org/browse/SPARK-106>`_ Added
-  helpers `MongoSpark.load` helpers for Java users using a SparkSesson.
-
-- `SPARK-100 <https://jira.mongodb.org/browse/SPARK-100>`_ Added
-  ``WriteConfig.replaceDocument`` to configure how Datasets are saved.
-
-- `SPARK-39 <https://jira.mongodb.org/browse/SPARK-39>`_ Added support
-  for Decimal type.
-
-- `SPARK-112 <https://jira.mongodb.org/browse/SPARK-112>`_ Fixed custom
-  partition key bug in ``MongoSamplePartitioner``.
-
-- `SPARK-122 <https://jira.mongodb.org/browse/SPARK-122>`_ Ensure
-  pagination partitioners can use a covered query.
-
-- `SPARK-101 <https://jira.mongodb.org/browse/SPARK-101>`_ Add support
-  for partial collection partitioning for non-sharded partitioners.
-
-- `SPARK-103 <https://jira.mongodb.org/browse/SPARK-103>`_ Ensure
-  partitioners handle empty collections.
-
-MongoDB Connector for Spark `2.0.0`_
-------------------------------------
-
-*Released November 1, 2016*
-
-- First Spark 2.0.0 release
-
-.. _2.0.0: https://github.com/mongodb/mongo-spark/releases/tag/r2.0.0
-.. _2.1.0: https://github.com/mongodb/mongo-spark/compare/r2.0.0...r2.1.0
-.. _2.2.0: https://github.com/mongodb/mongo-spark/compare/r2.1.0...r2.2.0
-.. _2.2.1: https://github.com/mongodb/mongo-spark/compare/r2.2.0...r2.2.1
-.. _2.2.2: https://github.com/mongodb/mongo-spark/compare/r2.2.1...r2.2.2
-.. _2.2.3: https://github.com/mongodb/mongo-spark/compare/r2.2.2...r2.2.3
 .. _2.3.0: https://github.com/mongodb/mongo-spark/compare/r2.2.3...r2.3.0
 .. _2.3.1: https://github.com/mongodb/mongo-spark/compare/r2.3.0...r2.3.1
+.. _2.3.2: https://github.com/mongodb/mongo-spark/compare/r2.3.1...r2.3.2

--- a/source/scala-api.txt
+++ b/source/scala-api.txt
@@ -64,9 +64,9 @@ a `SBT <http://www.scala-sbt.org/documentation.html>`_ ``build.scala`` file:
 
    scalaVersion := "2.11.7",
    libraryDependencies ++= Seq(
-     "org.mongodb.spark" %% "mongo-spark-connector" % "2.3.1",
-     "org.apache.spark" %% "spark-core" % "2.3.2",
-     "org.apache.spark" %% "spark-sql" % "2.3.2"
+     "org.mongodb.spark" %% "mongo-spark-connector" % "{+current-version+}",
+     "org.apache.spark" %% "spark-core" % "{+spark-core-version+}",
+     "org.apache.spark" %% "spark-sql" % "{+spark-sql-version+}"
    )
 
 Configuration


### PR DESCRIPTION
**Note:** Ignore the version selector.

Staging: 

- [Index](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12292/index.html)
- [Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12292/release-notes.html)
- [Java](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12292/java-api.html)
- [Scala](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12292/scala-api.html)
- [Python](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12292/python-api.html)
- [R](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12292/r-api.html)
