### PR TITLE
DOCS-12294 - Release version 2.1.5

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -30,7 +30,9 @@ extensions = [
     'sphinx.ext.todo',
     'mongodb',
     'directives',
-    'intermanual'
+    'intermanual',
+    'fasthtml',
+    'source_constants'
 ]
 
 templates_path = ['.templates']
@@ -57,6 +59,12 @@ rst_epilog = '\n'.join([
 extlinks = {
     'manual': ('https://docs.mongodb.com/manual%s', ''),
     'mongo-spark': ('https://github.com/mongodb/mongo-spark%s', ''),
+}
+
+source_constants = {
+    'current-version': '2.1.5',
+    'spark-core-version': '2.1.3',
+    'spark-sql-version': '2.1.3'
 }
 
 intersphinx_mapping = {}

--- a/source/includes/extracts-command-line.yaml
+++ b/source/includes/extracts-command-line.yaml
@@ -39,8 +39,8 @@ content: |
 
       ./bin/spark-shell --conf "spark.mongodb.input.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
                         --conf "spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection" \
-                        --packages org.mongodb.spark:mongo-spark-connector_2.11:2.1.4
- 
+                        --packages org.mongodb.spark:mongo-spark-connector_2.11:{+current-version+}
+
    .. include:: /includes/extracts/list-configuration-explanation.rst
 
 ---
@@ -56,8 +56,8 @@ content: |
 
       ./bin/pyspark --conf "spark.mongodb.input.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
                     --conf "spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection" \
-                    --packages org.mongodb.spark:mongo-spark-connector_2.11:2.1.4
- 
+                    --packages org.mongodb.spark:mongo-spark-connector_2.11:{+current-version+}
+
    .. include:: /includes/extracts/list-configuration-explanation.rst
 
    The examples in this tutorial will use this database and collection.
@@ -73,7 +73,7 @@ content: |
 
       ./bin/sparkR  --conf "spark.mongodb.input.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
                     --conf "spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection" \
-                    --packages org.mongodb.spark:mongo-spark-connector_2.11:2.1.4
+                    --packages org.mongodb.spark:mongo-spark-connector_2.11:{+current-version+}
 
    .. include:: /includes/extracts/list-configuration-explanation.rst
 ...

--- a/source/includes/list-prerequisites.rst
+++ b/source/includes/list-prerequisites.rst
@@ -6,4 +6,4 @@
 
 - Spark 2.1.x.
 
-- Scala 2.11.x  
+- Scala 2.11.x.

--- a/source/index.txt
+++ b/source/index.txt
@@ -24,15 +24,19 @@ versions of Apache Spark and MongoDB:
      - Spark Version
      - MongoDB Version
 
-   * - 2.3.1
+   * - 2.4.0
+     - 2.4.x
+     - 2.6 or later
+
+   * - 2.3.2
      - 2.3.x
      - 2.6 or later
 
-   * - 2.2.5
+   * - 2.2.6
      - 2.2.x
      - 2.6 or later
 
-   * - **2.1.4**
+   * - **{+current-version+}**
      - **2.1.x**
      - **2.6 or later**
 
@@ -49,32 +53,37 @@ versions of Apache Spark and MongoDB:
 
 .. admonition:: Announcements
 
-   - **Oct 08, 2018**, `MongoDB Connector for Spark versions v2.3.1, v2.2.5 and v2.1.4
+   - **Dec 07, 2018**, `MongoDB Connector for Spark versions v2.4.0,
+     v2.3.2, v2.2.6, and v2.1.5
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **July 30, 2018**, `MongoDB Connector for Spark versions v2.3.0, v2.2.4 and v2.1.3
+   - **Oct 08, 2018**, `MongoDB Connector for Spark versions v2.3.1,
+     v2.2.5, and v2.1.4
+     <https://www.mongodb.com/products/spark-connector>`_ Released.
+
+   - **July 30, 2018**, `MongoDB Connector for Spark versions v2.3.0,
+     v2.2.4, and v2.1.3
      <https://www.mongodb.com/products/spark-connector>`_ Released.
    
-   - **June 19, 2018**, `MongoDB Connector for Spark versions v2.2.3 and v2.1.2
+   - **June 19, 2018**, `MongoDB Connector for Spark versions v2.2.3 and
+     v2.1.2
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **April 18, 2018**, `MongoDB Connector for Spark versions v2.2.2
+   - **April 18, 2018**, `MongoDB Connector for Spark version v2.2.2
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **Oct 31, 2017**, `MongoDB Connector for Spark versions v2.2.1 and v2.2.1
+   - **Oct 31, 2017**, `MongoDB Connector for Spark version v2.2.1
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **July 13, 2017**, `MongoDB Connector for Spark v2.2.0
+   - **July 13, 2017**, `MongoDB Connector for Spark version v2.2.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-   - **July 12, 2017**, `MongoDB Connector for Spark versions v2.2.0 and v2.1.0
+   - **July 12, 2017**, `MongoDB Connector for Spark versions v2.2.0 and
+     v2.1.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
    - **November 1, 2016**, `MongoDB Connector for Spark v2.0.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
-
-   - **Online course**. `Getting Started with Spark and MongoDB
-     <https://university.mongodb.com/courses/M233/about?jmp=docs>`_.
 
 .. class:: hidden
 
@@ -88,4 +97,4 @@ versions of Apache Spark and MongoDB:
       r-api
       faq
       release-notes
-      API Docs <https://www.javadoc.io/doc/org.mongodb.spark/mongo-spark-connector_2.11/2.1.4>
+      API Docs <https://www.javadoc.io/doc/org.mongodb.spark/mongo-spark-connector_2.11/{+current-version+}>

--- a/source/java-api.txt
+++ b/source/java-api.txt
@@ -15,7 +15,7 @@ Prerequisites
 
 .. include:: /includes/list-prerequisites.rst
 
-- Java 6 or later.
+- Java 8 or later.
 
 Getting Started
 ---------------
@@ -33,17 +33,17 @@ The following excerpt is from a Maven ``pom.xml`` file:
      <dependency>
        <groupId>org.mongodb.spark</groupId>
        <artifactId>mongo-spark-connector_2.11</artifactId>
-       <version>2.1.4</version>
+       <version>{+current-version+}</version>
      </dependency>
      <dependency>
        <groupId>org.apache.spark</groupId>
        <artifactId>spark-core_2.11</artifactId>
-       <version>2.1.3</version>
+       <version>{+spark-core-version+}</version>
      </dependency>
      <dependency>
        <groupId>org.apache.spark</groupId>
        <artifactId>spark-sql_2.11</artifactId>
-       <version>2.1.3</version>
+       <version>{+spark-sql-version+}</version>
      </dependency>
    </dependencies>
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -4,6 +4,15 @@ Release Notes
 
 .. default-domain:: mongodb
 
+
+MongoDB Connector for Spark `2.1.5`_
+------------------------------------
+
+*Released on December 7, 2018*
+
+- Ensure ``WriteConfig.ordered`` is applied to write operations.
+- Fixed ``MongoSpark.toDF()`` to use the provided ``MongoConnector``.
+
 MongoDB Connector for Spark `2.1.4`_
 ------------------------------------
 
@@ -123,16 +132,9 @@ MongoDB Connector for Spark `2.1.0`_
 - `SPARK-103 <https://jira.mongodb.org/browse/SPARK-103>`_ Ensure
   partitioners handle empty collections.
 
-MongoDB Connector for Spark `2.0.0`_
-------------------------------------
-
-*Released on November 1, 2016*
-
-- First Spark 2.0.0 release
-
-.. _2.0.0: https://github.com/mongodb/mongo-spark/releases/tag/r2.0.0
 .. _2.1.0: https://github.com/mongodb/mongo-spark/compare/r2.0.0...r2.1.0
 .. _2.1.1: https://github.com/mongodb/mongo-spark/compare/r2.1.0...r2.1.1
 .. _2.1.2: https://github.com/mongodb/mongo-spark/compare/r2.1.1...r2.1.2
 .. _2.1.3: https://github.com/mongodb/mongo-spark/compare/r2.1.2...r2.1.3
 .. _2.1.4: https://github.com/mongodb/mongo-spark/compare/r2.1.3...r2.1.4
+.. _2.1.5: https://github.com/mongodb/mongo-spark/compare/r2.1.4...r2.1.5

--- a/source/scala-api.txt
+++ b/source/scala-api.txt
@@ -64,9 +64,9 @@ a `SBT <http://www.scala-sbt.org/documentation.html>`_ ``build.scala`` file:
 
    scalaVersion := "2.11.7",
    libraryDependencies ++= Seq(
-     "org.mongodb.spark" %% "mongo-spark-connector" % "2.1.4",
-     "org.apache.spark" %% "spark-core" % "2.1.3",
-     "org.apache.spark" %% "spark-sql" % "2.1.3"
+     "org.mongodb.spark" %% "mongo-spark-connector" % "{+current-version+}",
+     "org.apache.spark" %% "spark-core" % "{+spark-core-version+}",
+     "org.apache.spark" %% "spark-sql" % "{+spark-sql-version+}"
    )
 
 Configuration


### PR DESCRIPTION
**Note:** Ignore the version selector.

Staging: 

- [Index](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12294/index.html)
- [Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12294/release-notes.html)
- [Java](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12294/java-api.html)
- [Scala](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12294/scala-api.html)
- [Python](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12294/python-api.html)
- [R](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/jdestefano/DOCS-12294/r-api.html)
