### PR TITLE
DOCS-13573: [sparkConnector] add samplePoolSize config option

### DIFF
--- a/source/configuration.txt
+++ b/source/configuration.txt
@@ -128,6 +128,13 @@ The following options for reading from MongoDB are available:
 
        *Default*: 1000
 
+   * - ``samplePoolSize``
+
+     - The sample pool size, used to limit the results from which
+       to sample data.
+
+       *Default*: 10000
+
    * - ``partitioner``
 
      - The class name of the partitioner to use to partition the data.


### PR DESCRIPTION
Staged: [Input Configuration](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/stevenrenaker/DOCS-13573/configuration.html#input-configuration)