### PR TITLE
Snooty config v2.2

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -6,9 +6,9 @@ intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 toc_landing_pages = ["/java-api", "/python-api", "/scala-api", "/r-api"]
 
 [constants]
-current-version = "2.4.2"
-spark-core-version = "2.4.2"
-spark-sql-version = "2.4.2"
+current-version = "2.2.7"
+spark-core-version = "2.2.3"
+spark-sql-version = "2.2.3"
 
 [substitutions]
 copy = "unicode:: U+000A9"

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,0 +1,16 @@
+name = "spark-connector"
+title = "MongoDB Spark Connector"
+
+intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
+
+toc_landing_pages = ["/java-api", "/python-api", "/scala-api", "/r-api"]
+
+[constants]
+current-version = "2.4.2"
+spark-core-version = "2.4.2"
+spark-sql-version = "2.4.2"
+
+[substitutions]
+copy = "unicode:: U+000A9"
+ent-build = "MongoDB Enterprise"
+hardlink = "http://docs.mongodb.com/docs-spark-connector"

--- a/source/index.txt
+++ b/source/index.txt
@@ -89,16 +89,14 @@ versions of Apache Spark and MongoDB:
    - **November 1, 2016**, `MongoDB Connector for Spark v2.0.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-
-      configuration
-      scala-api
-      java-api
-      python-api
-      r-api
-      faq
-      release-notes
-      API Docs <https://www.javadoc.io/doc/org.mongodb.spark/mongo-spark-connector_2.11/{+current-version+}>
+   configuration
+   scala-api
+   java-api
+   python-api
+   r-api
+   faq
+   release-notes
+   API Docs <https://www.javadoc.io/doc/org.mongodb.spark/mongo-spark-connector_2.11/{+current-version+}>

--- a/source/java-api.txt
+++ b/source/java-api.txt
@@ -4,7 +4,7 @@ Spark Connector Java Guide
 
 .. default-domain:: mongodb
 
-.. admonition:: Source Code
+.. note:: Source Code
 
    For the source code that combines all of the Java examples, see
    :mongo-spark:`JavaIntroduction.java
@@ -117,12 +117,10 @@ Tutorials
 - :doc:`/java/aggregation`
 - :doc:`/java/datasets-and-sql`
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-
-      /java/write-to-mongodb
-      /java/read-from-mongodb
-      /java/aggregation
-      /java/datasets-and-sql
+   /java/write-to-mongodb
+   /java/read-from-mongodb
+   /java/aggregation
+   /java/datasets-and-sql

--- a/source/python-api.txt
+++ b/source/python-api.txt
@@ -10,7 +10,7 @@ Spark Connector Python Guide
    :depth: 2
    :class: singlecol
 
-.. admonition:: Source Code
+.. note:: Source Code
 
    For the source code that contains the examples below, see
    :mongo-spark:`introduction.py
@@ -76,13 +76,11 @@ Tutorials
 - :doc:`/python/aggregation`
 - :doc:`/python/filters-and-sql`
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-
-      /python/write-to-mongodb
-      /python/read-from-mongodb
-      /python/aggregation
-      /python/filters-and-sql
+   /python/write-to-mongodb
+   /python/read-from-mongodb
+   /python/aggregation
+   /python/filters-and-sql
 

--- a/source/python/read-from-mongodb.txt
+++ b/source/python/read-from-mongodb.txt
@@ -40,7 +40,7 @@ The above operation produces the following shell output:
     |-- type: string (nullable = true)
 
 If you need to read from a different MongoDB collection,
-use the `.option` method when reading data into a DataFrame.
+use the ``.option`` method when reading data into a DataFrame.
 
 To read from a collection called ``contacts`` in a database called
 ``people``, specify ``people.contacts`` in the input URI option.

--- a/source/r-api.txt
+++ b/source/r-api.txt
@@ -4,7 +4,7 @@ Spark Connector R Guide
 
 .. default-domain:: mongodb
 
-.. admonition:: Source Code
+.. note:: Source Code
 
    For the source code that contains the examples below, see
    :mongo-spark:`introduction.R
@@ -67,12 +67,10 @@ Tutorials
 - :doc:`/r/aggregation`
 - :doc:`/r/filters-and-sql`
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-
-      /r/write-to-mongodb
-      /r/read-from-mongodb
-      /r/aggregation
-      /r/filters-and-sql
+   /r/write-to-mongodb
+   /r/read-from-mongodb
+   /r/aggregation
+   /r/filters-and-sql

--- a/source/scala-api.txt
+++ b/source/scala-api.txt
@@ -4,7 +4,7 @@ Spark Connector Scala Guide
 
 .. default-domain:: mongodb
 
-.. admonition:: Source Code
+.. note:: Source Code
 
    For the source code that contains the examples below, see
    :mongo-spark:`Introduction.scala
@@ -139,13 +139,11 @@ Tutorials
 - :doc:`/scala/datasets-and-sql`
 - :doc:`/scala/streaming`
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-   
-      /scala/write-to-mongodb
-      /scala/read-from-mongodb
-      /scala/aggregation
-      /scala/datasets-and-sql
-      /scala/streaming
+   /scala/write-to-mongodb
+   /scala/read-from-mongodb
+   /scala/aggregation
+   /scala/datasets-and-sql
+   /scala/streaming

--- a/source/scala/datasets-and-sql.txt
+++ b/source/scala/datasets-and-sql.txt
@@ -4,7 +4,7 @@ Datasets and SQL
 
 .. default-domain:: mongodb
 
-.. admonition:: Source Code
+.. note:: Source Code
 
    For the source code that contains the examples below, see
    :mongo-spark:`SparkSQL.scala

--- a/worker.sh
+++ b/worker.sh
@@ -1,0 +1,1 @@
+"build-and-stage-next-gen"


### PR DESCRIPTION
Staging: https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/snooty-config-v2.2/
Log: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=5f3c21a72f9a5cfb5bfa82e1

```
WARNING(index.txt:53ish): Directive "admonition" has been deprecated
WARNING(configuration.txt:182ish): Monospace text uses two backticks (``)
```

We've deprecated the generic `admonition`, but the named admonitions support titles, so it all works out. Refer to the callouts section of the style guide for guidance.

The `Monospace text uses two backticks…` warning is a false positive that docutils sometimes emits when it gets confused by a `:ref:` -- please ignore it.