### PR TITLE
(DOCSP-14335) Update Spark release versions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -62,9 +62,9 @@ extlinks = {
 }
 
 source_constants = {
-    'current-version': '3.0.0',
-    'spark-core-version': '3.0.0',
-    'spark-sql-version': '3.0.0'
+    'current-version': '3.0.1',
+    'spark-core-version': '3.0.1',
+    'spark-sql-version': '3.0.1'
 }
 
 intersphinx_mapping = {}

--- a/snooty.toml
+++ b/snooty.toml
@@ -6,9 +6,9 @@ intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 toc_landing_pages = ["/java-api", "/python-api", "/scala-api", "/r-api"]
 
 [constants]
-current-version = "3.0.0"
-spark-core-version = "3.0.0"
-spark-sql-version = "3.0.0"
+current-version = "3.0.1"
+spark-core-version = "3.0.1"
+spark-sql-version = "3.0.1"
 
 [substitutions]
 copy = "unicode:: U+000A9"

--- a/source/index.txt
+++ b/source/index.txt
@@ -28,15 +28,19 @@ versions of Apache Spark and MongoDB:
      - **3.0.x**
      - **2.6 or later**
 
-   * - 2.3.4
+   * - 2.4.3
+     - 2.4.x
+     - 2.6 or later
+
+   * - 2.3.5
      - 2.3.x
      - 2.6 or later
 
-   * - 2.2.8
+   * - 2.2.9
      - 2.2.x
      - 2.6 or later
 
-   * - 2.1.7
+   * - 2.1.8
      - 2.1.x
      - 2.6 or later
 


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-14335)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/zach.carr/DOCSP-14335/index.html)

Updated compatibility table according to ticket, updated `conf.py` and `snooty.toml` 3.0.0 source constants to 3.0.1.