### PR TITLE
(DOCSP-15313): Removed unique values from the shardkey description.

### DIFF
--- a/source/configuration.txt
+++ b/source/configuration.txt
@@ -116,7 +116,7 @@ The following options for reading from MongoDB are available:
 
    * - ``readPreference.tagSets``
 
-     - The `ReadPreference` TagSets to use.
+     - The ``ReadPreference`` TagSets to use.
 
    * - ``readConcern.level``
 
@@ -191,7 +191,7 @@ The following options for reading from MongoDB are available:
        To configure options for the various partitioner, see
        :ref:`partitioner-conf`.
 
-       *Default*: MongoDefaultPartitioner
+       *Default*: ``MongoDefaultPartitioner``
 
    * - ``registerSQLHelperFunctions``
 
@@ -285,7 +285,7 @@ Partitioner Configuration
    * - ``shardkey``
 
      - The field by which to split the collection data. The field
-       should be indexed and contain unique values.
+       should be indexed.
 
        *Default*: ``_id``
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -55,7 +55,7 @@ versions of Apache Spark and MongoDB:
 
 ----
 
-.. admonition:: Announcements
+.. note:: **Announcements**
 
    - **August 17, 2020**, `MongoDB Connector for Spark version v3.0.0
      <https://www.mongodb.com/products/spark-connector>`_ Released.


### PR DESCRIPTION
@nathan-contino-mongo, I removed "and contain unique values" from the following `shardkey` description. I also fixed a couple of minor issues that cause build warnings.

[STAGE](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-15313/configuration/#mongoshardedpartitioner-configuration)

[JIRA](https://jira.mongodb.org/browse/DOCSP-15313)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=607edaaa09293ae62667070d)