### PR TITLE
fix wrong variable name

### DIFF
--- a/source/java/write-to-mongodb.txt
+++ b/source/java/write-to-mongodb.txt
@@ -34,7 +34,7 @@ Write to MongoDB
        JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
          
        // Create a RDD of 10 documents
-       JavaRDD<Document> documents = jsc.parallelize(asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).map
+       JavaRDD<Document> sparkDocuments = jsc.parallelize(asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).map
                (new Function<Integer, Document>() {
          public Document call(final Integer i) throws Exception {
              return Document.parse("{test: " + i + "}");


### PR DESCRIPTION
In line 45 of the same file there saves JavaRDD<Document> object with name `sparkDocuments`
```java
MongoSpark.save(sparkDocuments, writeConfig);  
```
So in line 37 it should replace the variable name `documents` with `sparkDocuments`