### PR TITLE
(DOCSP-18818) Improve documentation for unsupported types

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -59,8 +59,11 @@ from extended JSON-like representations of those data types that are
 compatible with Spark. See :ref:`<bson-spark-datatypes>` for a list of 
 custom MongoDB types and their Spark counterparts.
 
+Spark Datasets
+~~~~~~~~~~~~~~
+
 To create a standard Dataset with custom MongoDB data types, use 
-``fieldType`` helpers:
+``fieldType`` helpers: 
 
 .. code-block:: scala
    
@@ -69,6 +72,16 @@ To create a standard Dataset with custom MongoDB data types, use
    case class MyData(id: fieldTypes.ObjectId, a: Int)
    val ds = spark.createDataset(Seq(MyData(fieldTypes.ObjectId(new ObjectId()), 99)))
    ds.show()
+
+The example above creates a Dataset where:
+
+- The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
+  using the helper ``fieldTypes.ObjectId``.
+
+- The ``a`` field is an ``Int``, a data type available in Spark.
+
+Spark DataFrames
+~~~~~~~~~~~~~~~~
 
 To create DataFrames with custom MongoDB data types:
 
@@ -93,3 +106,10 @@ To create DataFrames with custom MongoDB data types:
    val schema = StructType(List(StructFields.objectId("id", true), StructField("a", IntegerType, true)))
    val df = spark.createDataFrame(rdd, schema)
    df.show()
+
+The example above creates a DataFrame where:
+
+- The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
+  using ``StructFields.objectId``.
+
+- The ``a`` field is an ``Int``, a data type available in Spark.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -47,3 +47,49 @@ In MongoDB deployments with mixed versions of :binary:`~bin.mongod`, it is
 possible to get an ``Unrecognized pipeline stage name: '$sample'``
 error. To mitigate this situation, explicitly configure the partitioner
 to use and define the Schema when using DataFrames.
+
+How do I use MongoDB BSON types that are unsupported in Spark?
+--------------------------------------------------------------
+
+Some custom MongoDB BSON types, such as ``ObjectId``\s, are unsupported 
+in Spark.
+
+The MongoDB Spark Connector converts custom MongoDB data types to and 
+from extended JSON-like representations of those data types that are 
+compatible with Spark. See :ref:`<bson-spark-datatypes>` for a list of 
+custom MongoDB types and their Spark counterparts.
+
+To create a standard Dataset with custom MongoDB data types, use 
+``fieldType`` helpers:
+
+.. code-block:: scala
+   
+   import com.mongodb.spark.sql.fieldTypes
+ 
+   case class MyData(id: fieldTypes.ObjectId, a: Int)
+   val ds = spark.createDataset(Seq(MyData(fieldTypes.ObjectId(new ObjectId()), 99)))
+   ds.show()
+
+To create DataFrames with custom MongoDB data types:
+
+- Create RDD[Document]s using custom MongoDB BSON types 
+  (e.g. ``ObjectId``). The MongoDB Spark Connector handles converting 
+  those custom types into Spark-compatible data types.
+
+- Declare schemas using the ``StructFields`` helpers for data types 
+  that are not natively supported by Spark 
+  (e.g. ``StructFields.objectId``). Refer to 
+  :ref:`<bson-spark-datatypes>` for the Spark data structure 
+  underlying each custom MongoDB BSON type.
+
+.. code-block:: scala
+   
+   import org.apache.spark.sql.Row
+   import org.apache.spark.sql.types.{StructType, StructField, IntegerType}
+   import com.mongodb.spark.sql.helpers.StructFields
+ 
+   val data = Seq(Row(Row(new ObjectId().toHexString()), 99))
+   val rdd = spark.sparkContext.parallelize(data)
+   val schema = StructType(List(StructFields.objectId("id", true), StructField("a", IntegerType, true)))
+   val df = spark.createDataFrame(rdd, schema)
+   df.show()

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -72,7 +72,7 @@ To create a standard Dataset with custom MongoDB data types, use
 
 To create DataFrames with custom MongoDB data types:
 
-- Create RDD[Document]s using custom MongoDB BSON types 
+- Create RDDs using custom MongoDB BSON types 
   (e.g. ``ObjectId``). The MongoDB Spark Connector handles converting 
   those custom types into Spark-compatible data types.
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -79,8 +79,8 @@ To create DataFrames with custom MongoDB data types:
 - Declare schemas using the ``StructFields`` helpers for data types 
   that are not natively supported by Spark 
   (e.g. ``StructFields.objectId``). Refer to 
-  :ref:`<bson-spark-datatypes>` for the Spark data structure 
-  underlying each custom MongoDB BSON type.
+  :ref:`<bson-spark-datatypes>` for the data structure 
+  underlying each custom MongoDB BSON type in Spark.
 
 .. code-block:: scala
    

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -51,7 +51,7 @@ to use and define the Schema when using DataFrames.
 How do I use MongoDB BSON types that are unsupported in Spark?
 --------------------------------------------------------------
 
-Some custom MongoDB BSON types, such as ``ObjectId``\s, are unsupported 
+Some custom MongoDB BSON types, such as ``ObjectId``, are unsupported 
 in Spark.
 
 The MongoDB Spark Connector converts custom MongoDB data types to and 
@@ -63,7 +63,7 @@ Spark Datasets
 ~~~~~~~~~~~~~~
 
 To create a standard Dataset with custom MongoDB data types, use 
-``fieldType`` helpers: 
+``fieldTypes`` helpers:
 
 .. code-block:: scala
    
@@ -73,27 +73,29 @@ To create a standard Dataset with custom MongoDB data types, use
    val ds = spark.createDataset(Seq(MyData(fieldTypes.ObjectId(new ObjectId()), 99)))
    ds.show()
 
-The example above creates a Dataset where:
+The preceding example creates a Dataset containing the following fields 
+and value types:
 
 - The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
-  with ``fieldTypes.ObjectId``.
+  by ``fieldTypes.ObjectId``.
 
 - The ``a`` field is an ``Int``, a data type available in Spark.
 
 Spark DataFrames
 ~~~~~~~~~~~~~~~~
 
-To create DataFrames with custom MongoDB data types:
+To create a DataFrame with custom MongoDB data types, you must supply 
+those types when your create your RDD and schema:
 
 - Create RDDs using custom MongoDB BSON types 
-  (e.g. ``ObjectId``). The MongoDB Spark Connector handles converting 
+  (e.g. ``ObjectId``). The Spark Connector handles converting 
   those custom types into Spark-compatible data types.
 
 - Declare schemas using the ``StructFields`` helpers for data types 
   that are not natively supported by Spark 
   (e.g. ``StructFields.objectId``). Refer to 
-  :ref:`<bson-spark-datatypes>` for the data structure 
-  underlying each custom MongoDB BSON type in Spark.
+  :ref:`<bson-spark-datatypes>` for the mapping between BSON and custom 
+  MongoDB Spark types.
 
 .. code-block:: scala
    
@@ -107,9 +109,10 @@ To create DataFrames with custom MongoDB data types:
    val df = spark.createDataFrame(rdd, schema)
    df.show()
 
-The example above creates a DataFrame where:
+The preceding example creates a DataFrame containing the following 
+fields and value types:
 
 - The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
-  with ``StructFields.objectId``.
+  by ``StructFields.objectId``.
 
 - The ``a`` field is an ``Int``, a data type available in Spark.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -74,7 +74,7 @@ To create a standard Dataset with custom MongoDB data types, use
    ds.show()
 
 The preceding example creates a Dataset containing the following fields 
-and value types:
+and data types:
 
 - The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
   by ``fieldTypes.ObjectId``.
@@ -110,7 +110,7 @@ those types when you create the RDD and schema:
    df.show()
 
 The preceding example creates a DataFrame containing the following 
-fields and value types:
+fields and data types:
 
 - The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
   by ``StructFields.objectId``.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -76,7 +76,7 @@ To create a standard Dataset with custom MongoDB data types, use
 The example above creates a Dataset where:
 
 - The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
-  using the helper ``fieldTypes.ObjectId``.
+  with ``fieldTypes.ObjectId``.
 
 - The ``a`` field is an ``Int``, a data type available in Spark.
 
@@ -110,6 +110,6 @@ To create DataFrames with custom MongoDB data types:
 The example above creates a DataFrame where:
 
 - The ``id`` field is a custom MongoDB BSON type, ``ObjectId``, defined 
-  using ``StructFields.objectId``.
+  with ``StructFields.objectId``.
 
 - The ``a`` field is an ``Int``, a data type available in Spark.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -85,7 +85,7 @@ Spark DataFrames
 ~~~~~~~~~~~~~~~~
 
 To create a DataFrame with custom MongoDB data types, you must supply 
-those types when your create your RDD and schema:
+those types when you create the RDD and schema:
 
 - Create RDDs using custom MongoDB BSON types 
   (e.g. ``ObjectId``). The Spark Connector handles converting 

--- a/source/scala/datasets-and-sql.txt
+++ b/source/scala/datasets-and-sql.txt
@@ -262,21 +262,23 @@ to MongoDB using the DataFrameWriter directly:
    centenarians.write.option("collection", "hundredClub").mode("overwrite").mongo()
    centenarians.write.option("collection", "hundredClub").mode("overwrite").format("mongo").save()
 
+.. _bson-spark-datatypes:
+
 DataTypes
 ---------
 
 Spark supports a limited number of data types to ensure that all BSON
 types can be round tripped in and out of Spark DataFrames/Datasets. For
-any unsupported Bson Types, custom StructTypes are created. 
+any unsupported BSON Types, custom StructTypes are created. 
 
-The following table shows the mapping between the Bson Types and Spark
+The following table shows the mapping between the BSON Types and Spark
 Types:
 
 .. list-table::
    :header-rows: 1
    :widths: 25 75
 
-   * - Bson Type
+   * - BSON Type
      - Spark Type
 
    * - ``Document``
@@ -352,7 +354,7 @@ represent the unsupported BSON Types:
    :widths: 45 30 30
 
 
-   * - Bson Type
+   * - BSON Type
      - Scala case class
      - JavaBean
 

--- a/source/scala/datasets-and-sql.txt
+++ b/source/scala/datasets-and-sql.txt
@@ -268,8 +268,9 @@ DataTypes
 ---------
 
 Spark supports a limited number of data types to ensure that all BSON
-types can be round tripped in and out of Spark DataFrames/Datasets. For
-any unsupported BSON Types, custom StructTypes are created. 
+types can be round tripped in and out of Spark DataFrames/Datasets. The 
+Spark Connector creates custom StructTypes for any unsupported BSON 
+types.
 
 The following table shows the mapping between the BSON Types and Spark
 Types:


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18818

Added an FAQ item on using MongoDB BSON types that are unsupported in Spark.

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61a663a55314b0809f2ab659

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-18818/faq/#how-do-i-use-mongodb-bson-types-that-are-unsupported-in-spark-

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### Questions for reviewer
- I haven't tested the examples - they are pulled from Ross's comments in https://jira.mongodb.org/browse/SPARK-132. Do we need to test all code examples or is a technical review to confirm acceptable? 
- Do we need examples in other languages, or to more clearly label the examples "Scala?"  