### PR TITLE
(DOCSP-20565) v10 partitioners

### DIFF
--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -80,46 +80,38 @@ You can configure the following properties to read from MongoDB:
 
        The connector provides the following partitioners:
 
-       - ``MongoSamplePartitioner``
+       - ``SamplePartitioner``
              **Requires MongoDB 3.2**. A general purpose partitioner for
              all deployments. Uses the average document size and random
              sampling of the collection to determine suitable
              partitions for the collection. For configuration 
-             settings for the MongoSamplePartitioner, see
-             :ref:`conf-mongosamplepartitioner`.
+             settings for the SamplePartitioner, see
+             :ref:`conf-samplepartitioner`.
 
-       - ``MongoShardedPartitioner``
+       - ``ShardedPartitioner``
              A partitioner for sharded clusters. Partitions the
              collection based on the data chunks. Requires read access
              to the ``config`` database. For configuration settings for
-             the MongoShardedPartitioner, see
-             :ref:`conf-mongoshardedpartitioner`.
+             the ShardedPartitioner, see :ref:`conf-shardedpartitioner`.
 
-       - ``MongoSplitVectorPartitioner``
-             A partitioner for standalone or replica sets. Uses the
-             :dbcommand:`splitVector` command on the standalone or the
-             primary to determine the partitions of the database.
-             Requires privileges to run :dbcommand:`splitVector`
-             command. For configuration settings for the
-             MongoSplitVectorPartitioner, see
-             :ref:`conf-mongosplitvectorpartitioner`.
-
-       - ``MongoPaginateByCountPartitioner``
-             A slow, general purpose partitioner for all deployments.
-             Creates a specific number of partitions. Requires a query
-             for every partition. For configuration settings for the
-             MongoPaginateByCountPartitioner, see
-             :ref:`conf-mongopaginatebycountpartitioner`.
-
-       - ``MongoPaginateBySizePartitioner``
+       - ``PaginateBySizePartitioner``
              A slow, general purpose partitioner for all deployments.
              Creates partitions based on data size. Requires a query
              for every partition. For configuration settings for the
-             MongoPaginateBySizePartitioner, see
-             :ref:`conf-mongopaginatebysizepartitioner`.
+             PaginateBySizePartitioner, see 
+             :ref:`conf-paginatebysizepartitioner`.
+
+       - ``PaginateIntoPartitionsPartitioner``
+             
+             A partitioner to create the maximum number of partitions 
+             on a collection. Uses the count and the average document 
+             size of a collection to calculate the number of documents 
+             to include in each partition. For configuration settings 
+             for the PaginateIntoPartitionsPartitioner, see
+             :ref:`conf-paginateintopartitionspartitioner`.
 
        You can also specify a custom partitioner implementation. For
-       custom implementations of the ``MongoPartitioner`` trait, provide
+       custom implementations of the ``Partitioner`` trait, provide
        the full class name. If you don't provide package names, then
        this property uses the default package,
        ``com.mongodb.spark.rdd.partitioner``.
@@ -127,7 +119,7 @@ You can configure the following properties to read from MongoDB:
        To configure options for the various partitioners, see
        :ref:`partitioner-conf`.
       
-       **Default:** ``MongoDefaultPartitioner``
+       **Default:** ``SamplePartitioner``
 
    * - ``partitionerOptions``
      - The custom options to configure the partitioner.
@@ -177,10 +169,10 @@ You can configure the following properties to read from MongoDB:
 Partitioner Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _conf-mongosamplepartitioner:
+.. _conf-samplepartitioner:
 
-``MongoSamplePartitioner`` Configuration
-````````````````````````````````````````
+``SamplePartitioner`` Configuration
+```````````````````````````````````
 
 .. include:: /includes/sparkconf-partitioner-options-note.rst
 
@@ -226,17 +218,17 @@ Partitioner Configuration
 .. example::
 
    For a collection with 640 documents with an average document 
-   size of 0.5 MB, the default ``MongoSamplePartitioner`` configuration 
+   size of 0.5 MB, the default ``SamplePartitioner`` configuration 
    values creates 5 partitions with 128 documents per partition.
 
    The MongoDB Spark Connector samples 50 documents (the default 10 
    per intended partition) and defines 5 partitions by selecting 
    ``partitionKey`` ranges from the sampled documents.
 
-.. _conf-mongoshardedpartitioner:
+.. _conf-shardedpartitioner:
 
-``MongoShardedPartitioner`` Configuration
-`````````````````````````````````````````
+``ShardedPartitioner`` Configuration
+````````````````````````````````````
 
 .. include:: /includes/sparkconf-partitioner-options-note.rst
 
@@ -257,62 +249,10 @@ Partitioner Configuration
 
           This property is not compatible with hashed shard keys.
 
-.. _conf-mongosplitvectorpartitioner:
+.. _conf-paginatebysizepartitioner:
 
-``MongoSplitVectorPartitioner`` Configuration
-`````````````````````````````````````````````
-
-.. include:: /includes/sparkconf-partitioner-options-note.rst
-
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - Property name
-     - Description
-
-   * - ``partitionKey``
-     - The field by which to split the collection data. The field
-       should be indexed and contain unique values.
-
-       **Default:** ``_id``
-
-   * - ``partitionSizeMB``
-     - The size (in MB) for each partition. Smaller partition sizes 
-       create more partitions containing fewer documents.
-
-       **Default:** ``64``
-
-.. _conf-mongopaginatebycountpartitioner:
-
-``MongoPaginateByCountPartitioner`` Configuration
-`````````````````````````````````````````````````
-
-.. include:: /includes/sparkconf-partitioner-options-note.rst
-
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - Property name
-     - Description
-
-   * - ``partitionKey``
-     - The field by which to split the collection data. The field
-       should be indexed and contain unique values.
-
-       **Default:** ``_id``
-
-   * - ``numberOfPartitions``
-     - The number of partitions to create. A greater number of 
-       partitions means fewer documents per partition.
-
-       **Default:** ``64``
-
-.. _conf-mongopaginatebysizepartitioner:
-
-``MongoPaginateBySizePartitioner`` Configuration
-````````````````````````````````````````````````
+``PaginateBySizePartitioner`` Configuration
+```````````````````````````````````````````
 
 .. include:: /includes/sparkconf-partitioner-options-note.rst
 
@@ -334,6 +274,27 @@ Partitioner Configuration
        create more partitions containing fewer documents.
 
        **Default:** ``64``
+
+.. _conf-paginateintopartitionspartitioner:
+
+
+``PaginateIntoPartitionsPartitioner`` Configuration
+```````````````````````````````````````````````````
+
+.. include:: /includes/sparkconf-partitioner-options-note.rst
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Property name
+     - Description
+
+   * - ``partitionKey``
+     - The field by which to split the collection data. The field
+       should be indexed and contain unique values.
+
+       **Default:** ``_id``
 
 .. _configure-input-uri:
 

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -102,7 +102,7 @@ You can configure the following properties to read from MongoDB:
              :ref:`conf-paginatebysizepartitioner`.
 
        - ``PaginateIntoPartitionsPartitioner``
-             A partitioner that creates a specified maximum number of 
+             A partitioner that creates a specified number of 
              partitions for a collection. Uses the count and the 
              average document size of a collection to calculate the 
              number of documents to include in each partition. For 
@@ -300,8 +300,7 @@ Partitioner Configuration
        **Default:** ``_id``
 
    * - ``maxNumberOfPartitions``
-     - The maximum number of partitions this partitioner
-       will create.
+     - The number of partitions to create.
 
        **Default:** ``64``
 

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -102,12 +102,12 @@ You can configure the following properties to read from MongoDB:
              :ref:`conf-paginatebysizepartitioner`.
 
        - ``PaginateIntoPartitionsPartitioner``
-             
-             A partitioner to create the maximum number of partitions 
-             on a collection. Uses the count and the average document 
-             size of a collection to calculate the number of documents 
-             to include in each partition. For configuration settings 
-             for the PaginateIntoPartitionsPartitioner, see
+             A partitioner that creates a specified maximum number of 
+             partitions for a collection. Uses the count and the 
+             average document size of a collection to calculate the 
+             number of documents to include in each partition. For 
+             configuration settings for the 
+             PaginateIntoPartitionsPartitioner, see
              :ref:`conf-paginateintopartitionspartitioner`.
 
        You can also specify a custom partitioner implementation. For
@@ -184,8 +184,9 @@ Partitioner Configuration
      - Description
 
    * - ``partitionKey``
-     - The field by which to split the collection data. The field
-       should be indexed and contain unique values.
+     - A comma-delimited list of fields by which to split the 
+       collection data. The fields should be indexed and contain unique 
+       values.
 
        **Default:** ``_id``
 
@@ -264,8 +265,9 @@ Partitioner Configuration
      - Description
 
    * - ``partitionKey``
-     - The field by which to split the collection data. The field
-       should be indexed and contain unique values.
+     - A comma-delimited list of fields by which to split the 
+       collection data. The fields should be indexed and contain unique 
+       values.
 
        **Default:** ``_id``
 
@@ -291,10 +293,17 @@ Partitioner Configuration
      - Description
 
    * - ``partitionKey``
-     - The field by which to split the collection data. The field
-       should be indexed and contain unique values.
+     - A comma-delimited list of fields by which to split the 
+       collection data. The fields should be indexed and contain unique 
+       values.
 
        **Default:** ``_id``
+
+   * - ``maxNumberOfPartitions``
+     - The maximum number of partitions this partitioner
+       will create.
+
+       **Default:** ``64``
 
 .. _configure-input-uri:
 

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -12,15 +12,15 @@ Read Configuration Options
 
 .. _spark-input-conf:
 
-Input Configuration
---------------------
+Read Configuration
+------------------
 
 You can configure the following properties to read from MongoDB:
 
 .. note::
 
-   If you use ``SparkConf`` to set the connector's input configurations, 
-   prefix ``spark.mongodb.input.`` to each property.
+   If you use ``SparkConf`` to set the connector's read configurations, 
+   prefix ``spark.mongodb.read.`` to each property.
 
 .. list-table::
    :header-rows: 1
@@ -36,7 +36,7 @@ You can configure the following properties to read from MongoDB:
        address, or UNIX domain socket. If the connection string doesn't
        specify a ``port``, it uses the default MongoDB port, ``27017``.
 
-       You can append the other remaining input options to the ``uri``
+       You can append the other remaining read options to the ``uri``
        setting. See :ref:`configure-input-uri`.
 
    * - ``database``
@@ -286,7 +286,7 @@ This partitioner is not compatible with hashed shard keys.
 
        **Default:** ``_id``
 
-   * - ``maxNumberOfPartitions``
+   * - ``partitioner.options.maxNumberOfPartitions``
      - The number of partitions to create.
 
        **Default:** ``64``
@@ -296,36 +296,36 @@ This partitioner is not compatible with hashed shard keys.
 ``uri`` Configuration Setting
 -----------------------------
 
-You can set all :ref:`spark-input-conf` via the input ``uri`` setting.
+You can set all :ref:`spark-input-conf` via the read ``uri`` setting.
 
-For example, consider the following example which sets the input
+For example, consider the following example which sets the read
 ``uri`` setting via ``SparkConf``:
 
 .. note::
 
-   If you use ``SparkConf`` to set the connector's input configurations, 
-   prefix ``spark.mongodb.input.`` to the setting.
+   If you use ``SparkConf`` to set the connector's read configurations, 
+   prefix ``spark.mongodb.read.`` to the setting.
 
 .. code:: cfg
 
-   spark.mongodb.input.uri=mongodb://127.0.0.1/databaseName.collectionName?readPreference=primaryPreferred
+   spark.mongodb.read.uri=mongodb://127.0.0.1/databaseName.collectionName?readPreference=primaryPreferred
 
 The configuration corresponds to the following separate configuration
 settings:
 
 .. code:: cfg
 
-   spark.mongodb.input.uri=mongodb://127.0.0.1/
-   spark.mongodb.input.database=databaseName
-   spark.mongodb.input.collection=collectionName
-   spark.mongodb.input.readPreference.name=primaryPreferred
+   spark.mongodb.read.uri=mongodb://127.0.0.1/
+   spark.mongodb.read.database=databaseName
+   spark.mongodb.read.collection=collectionName
+   spark.mongodb.read.readPreference.name=primaryPreferred
 
 If you specify a setting both in the ``uri`` and in a separate
 configuration, the ``uri`` setting overrides the separate
-setting. For example, given the following configuration, the input
+setting. For example, given the following configuration, the
 database for the connection is ``foobar``:
 
 .. code:: cfg
 
-   spark.mongodb.input.uri=mongodb://127.0.0.1/foobar
-   spark.mongodb.input.database=bar
+   spark.mongodb.read.uri=mongodb://127.0.0.1/foobar
+   spark.mongodb.read.database=bar

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -80,10 +80,6 @@ You can configure the following properties to read from MongoDB:
 
        The connector provides the following partitioners:
 
-       - ``MongoDefaultPartitioner``
-            **Default**. Wraps the MongoSamplePartitioner and provides
-            help for users of older versions of MongoDB.
-
        - ``MongoSamplePartitioner``
              **Requires MongoDB 3.2**. A general purpose partitioner for
              all deployments. Uses the average document size and random

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -81,7 +81,7 @@ You can configure the following properties to read from MongoDB:
        The connector provides the following partitioners:
 
        - ``SamplePartitioner``
-             **Requires MongoDB 3.2**. A general purpose partitioner for
+             A general purpose partitioner for
              all deployments. Uses the average document size and random
              sampling of the collection to determine suitable
              partitions for the collection. To learn more about the 
@@ -112,10 +112,8 @@ You can configure the following properties to read from MongoDB:
              :ref:`configuration settings description <conf-paginateintopartitionspartitioner>`.
 
        You can also specify a custom partitioner implementation. For
-       custom implementations of the ``Partitioner`` trait, provide
-       the full class name. If you don't provide package names, then
-       this property uses the default package,
-       ``com.mongodb.spark.rdd.partitioner``.
+       custom implementations of the ``Partitioner`` interface, provide
+       the full class name.
 
        To configure options for the various partitioners, see
        :ref:`partitioner-conf`.
@@ -185,20 +183,20 @@ Partitioner Configuration
    * - Property name
      - Description
 
-   * - ``partitionKey``
+   * - ``partitioner.options.partitionKey``
      - A comma-delimited list of fields by which to split the 
        collection data. The fields should be indexed and contain unique 
        values.
 
        **Default:** ``_id``
 
-   * - ``partitionSizeMB``
+   * - ``partitioner.options.partitionSizeMB``
      - The size (in MB) for each partition. Smaller partition sizes 
        create more partitions containing fewer documents.
 
        **Default:** ``64``
 
-   * - ``samplesPerPartition``
+   * - ``partitioner.options.samplesPerPartition``
      - The number of sample documents to take for each partition in 
        order to establish a ``partitionKey`` range for each partition. 
        
@@ -234,24 +232,10 @@ Partitioner Configuration
 ``ShardedPartitioner`` Configuration
 ````````````````````````````````````
 
-.. include:: /includes/sparkconf-partitioner-options-note.rst
+The ``ShardedPartitioner`` automatically determines 
+partitions to use based on your shard configuration. 
 
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - Property name
-     - Description
-
-   * - ``shardkey``
-     - The field by which to split the collection data. The field
-       should be indexed.
-
-       **Default:** ``_id``
-
-       .. important:: 
-
-          This property is not compatible with hashed shard keys.
+This partitioner is not compatible with hashed shard keys.
 
 .. _conf-mongopaginatebysizepartitioner:
 .. _conf-paginatebysizepartitioner:
@@ -268,14 +252,14 @@ Partitioner Configuration
    * - Property name
      - Description
 
-   * - ``partitionKey``
+   * - ``partitioner.options.partitionKey``
      - A comma-delimited list of fields by which to split the 
        collection data. The fields should be indexed and contain unique 
        values.
 
        **Default:** ``_id``
 
-   * - ``partitionSizeMB``
+   * - ``partitioner.options.partitionSizeMB``
      - The size (in MB) for each partition. Smaller partition sizes 
        create more partitions containing fewer documents.
 
@@ -295,7 +279,7 @@ Partitioner Configuration
    * - Property name
      - Description
 
-   * - ``partitionKey``
+   * - ``partitioner.options.partitionKey``
      - A comma-delimited list of fields by which to split the 
        collection data. The fields should be indexed and contain unique 
        values.

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -84,31 +84,32 @@ You can configure the following properties to read from MongoDB:
              **Requires MongoDB 3.2**. A general purpose partitioner for
              all deployments. Uses the average document size and random
              sampling of the collection to determine suitable
-             partitions for the collection. For configuration 
-             settings for the SamplePartitioner, see
-             :ref:`conf-samplepartitioner`.
+             partitions for the collection. To learn more about the 
+             ``SamplePartitioner``, see the 
+             :ref:`configuration settings description <conf-samplepartitioner>`.
 
        - ``ShardedPartitioner``
              A partitioner for sharded clusters. Partitions the
              collection based on the data chunks. Requires read access
-             to the ``config`` database. For configuration settings for
-             the ShardedPartitioner, see :ref:`conf-shardedpartitioner`.
+             to the ``config`` database. To learn more about the 
+             ``ShardedPartitioner``, see the 
+             :ref:`configuration settings description <conf-shardedpartitioner>`.
 
        - ``PaginateBySizePartitioner``
              A slow, general purpose partitioner for all deployments.
              Creates partitions based on data size. Requires a query
-             for every partition. For configuration settings for the
-             PaginateBySizePartitioner, see 
-             :ref:`conf-paginatebysizepartitioner`.
+             for every partition. To learn more about the 
+             ``PaginateBySizePartitioner``, see the 
+             :ref:`configuration settings description <conf-paginatebysizepartitioner>`.
 
        - ``PaginateIntoPartitionsPartitioner``
              A partitioner that creates a specified number of 
-             partitions for a collection. Uses the count and the 
-             average document size of a collection to calculate the 
-             number of documents to include in each partition. For 
-             configuration settings for the 
-             PaginateIntoPartitionsPartitioner, see
-             :ref:`conf-paginateintopartitionspartitioner`.
+             partitions for a collection. Uses the total number of 
+             documents and the average document size in a collection to 
+             calculate the number of documents to include in each 
+             partition. To learn more about the 
+             ``PaginateIntoPartitionsPartitioner``, see the 
+             :ref:`configuration settings description <conf-paginateintopartitionspartitioner>`.
 
        You can also specify a custom partitioner implementation. For
        custom implementations of the ``Partitioner`` trait, provide
@@ -169,6 +170,7 @@ You can configure the following properties to read from MongoDB:
 Partitioner Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _conf-mongosamplepartitioner:
 .. _conf-samplepartitioner:
 
 ``SamplePartitioner`` Configuration
@@ -226,6 +228,7 @@ Partitioner Configuration
    per intended partition) and defines 5 partitions by selecting 
    ``partitionKey`` ranges from the sampled documents.
 
+.. _conf-mongoshardedpartitioner:
 .. _conf-shardedpartitioner:
 
 ``ShardedPartitioner`` Configuration
@@ -250,6 +253,7 @@ Partitioner Configuration
 
           This property is not compatible with hashed shard keys.
 
+.. _conf-mongopaginatebysizepartitioner:
 .. _conf-paginatebysizepartitioner:
 
 ``PaginateBySizePartitioner`` Configuration
@@ -278,7 +282,6 @@ Partitioner Configuration
        **Default:** ``64``
 
 .. _conf-paginateintopartitionspartitioner:
-
 
 ``PaginateIntoPartitionsPartitioner`` Configuration
 ```````````````````````````````````````````````````

--- a/source/configuration/write.txt
+++ b/source/configuration/write.txt
@@ -12,15 +12,15 @@ Write Configuration Options
 
 .. _spark-output-conf:
 
-Output Configuration
---------------------
+Write Configuration
+-------------------
 
 The following options for writing to MongoDB are available:
 
 .. note::
 
-   If you use ``SparkConf`` to set the connector's output configurations,
-   prefix ``spark.mongodb.output.`` to each property.
+   If you use ``SparkConf`` to set the connector's write configurations,
+   prefix ``spark.mongodb.write.`` to each property.
 
 .. list-table::
    :header-rows: 1
@@ -103,35 +103,35 @@ The following options for writing to MongoDB are available:
 ``uri`` Configuration Setting
 -----------------------------
 
-You can set all :ref:`spark-output-conf` via the output ``uri``.
+You can set all :ref:`spark-output-conf` via the write ``uri``.
 
-For example, consider the following example which sets the input
+For example, consider the following example which sets the write
 ``uri`` setting via ``SparkConf``:
 
 .. note::
 
-   If you use ``SparkConf`` to set the connector's output configurations,
-   prefix ``spark.mongodb.output.`` to the setting.
+   If you use ``SparkConf`` to set the connector's write configurations,
+   prefix ``spark.mongodb.write.`` to the setting.
 
 .. code:: cfg
 
-   spark.mongodb.output.uri=mongodb://127.0.0.1/test.myCollection
+   spark.mongodb.write.uri=mongodb://127.0.0.1/test.myCollection
 
 The configuration corresponds to the following separate configuration
 settings:
 
 .. code:: cfg
 
-   spark.mongodb.output.uri=mongodb://127.0.0.1/
-   spark.mongodb.output.database=test
-   spark.mongodb.output.collection=myCollection
+   spark.mongodb.write.uri=mongodb://127.0.0.1/
+   spark.mongodb.write.database=test
+   spark.mongodb.write.collection=myCollection
 
 If you specify a setting both in the ``uri`` and in a separate
 configuration, the ``uri`` setting overrides the separate
-setting. For example, given the following configuration, the output
+setting. For example, given the following configuration, the
 database for the connection is ``foobar``:
 
 .. code:: cfg
 
-   spark.mongodb.output.uri=mongodb://127.0.0.1/foobar
-   spark.mongodb.output.database=bar
+   spark.mongodb.write.uri=mongodb://127.0.0.1/foobar
+   spark.mongodb.write.database=bar

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -28,7 +28,7 @@ To promote data locality,
   same nodes and use :ref:`localThreshold <spark-input-conf>`
   configuration to connect to the nearest :binary:`~bin.mongos`. 
   To partition the data by shard use the 
-  :ref:`conf-mongoshardedpartitioner`.
+  :ref:`conf-shardedpartitioner`.
 
 How do I interact with Spark Streams?
 -------------------------------------

--- a/source/includes/sparkconf-partitioner-options-note.rst
+++ b/source/includes/sparkconf-partitioner-options-note.rst
@@ -1,6 +1,8 @@
 
 .. note::
 
-   If you use ``SparkConf`` to set the connector's input configurations, 
-   prefix ``spark.mongodb.input.partitionerOptions.`` to each property.
+   If you use ``SparkConf`` to set the connector's input 
+   configurations, prefix each property with 
+   ``spark.mongodb.input.partitionerOptions.`` 
+   instead of ``partitioner.options.``.
    


### PR DESCRIPTION
## Pull Request Info
Documenting the partitioners in this PR: https://github.com/mongodb/mongo-spark/pull/63

This is old Spark content, updated for v10. Several partitioners are removed.

**For tech review**
Please confirm the partitioner option names, I'm not sure if they've changed. `partitionKey` in particular is a list now.

- partitionKey
- partitionSizeMB
- samplesPerPartition
- shardkey
- maxNumberOfPartitions

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-20565

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=621bd1a09c4c7f6bfbfe1079

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-20565/configuration/read/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
