### PR TITLE
(DOCSP-21735) Add fullDocument config option

### DIFF
--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -293,6 +293,25 @@ This partitioner is not compatible with hashed shard keys.
 
        **Default:** ``64``
 
+Change Streams
+--------------
+
+.. note::
+
+   If you use ``SparkConf`` to set the connector's read configurations, 
+   prefix ``spark.mongodb.change.stream.`` to each property.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - ``publish.full.document.only``
+
+     - If ``true``, publish only the changed document instead of the 
+       full change stream document.
+
+       **Default:** ``false``
+
 .. _configure-input-uri:
 
 ``uri`` Configuration Setting

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -300,8 +300,9 @@ Change Streams
 
 .. note::
 
-   If you use ``SparkConf`` to set the connector's read configurations, 
-   prefix ``spark.mongodb.change.stream.`` to each property.
+   If you use ``SparkConf`` to set the connector's change stream 
+   configurations, prefix ``spark.mongodb.change.stream.`` to each 
+   property.
 
 .. list-table::
    :header-rows: 1

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -315,6 +315,7 @@ Change Streams
 
        **Default:** ``false``
 
+
 .. _configure-input-uri:
 
 ``uri`` Configuration Setting

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -293,6 +293,8 @@ This partitioner is not compatible with hashed shard keys.
 
        **Default:** ``64``
 
+.. _spark-change-stream-conf:
+
 Change Streams
 --------------
 

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -308,10 +308,39 @@ Change Streams
    :header-rows: 1
    :widths: 35 65
 
+   * - Property name
+     - Description
+
+   * - ``lookup.full.document``
+
+     - If ``true``, 
+     
+       Determines what values your change stream returns on update 
+       operations.
+
+       The default setting returns the differences between the original 
+       document and the updated document.
+
+       The ``updateLookup`` setting returns the differences between the 
+       original document and updated document as well as a copy of the 
+       entire updated document.
+
+       .. tip::
+          
+          For more information on how this change stream option works, 
+          see the MongoDB server manual guide 
+          :manual:`Lookup Full Document for Update Operation </changeStreams/#lookup-full-document-for-update-operations>`.
+
+       **Default:** ""
+
    * - ``publish.full.document.only``
 
-     - If ``true``, publish only the changed document instead of the 
+     - If ``true``, returns only the changed document instead of the 
        full change stream document.
+
+       When set to ``true``, the connector automatically sets the 
+       ``lookup.full.document`` property to ``updateLookup`` to receive 
+       the updated documents.
 
        **Default:** ``false``
 

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -313,9 +313,7 @@ Change Streams
 
    * - ``lookup.full.document``
 
-     - If ``true``, 
-     
-       Determines what values your change stream returns on update 
+     - Determines what values your change stream returns on update 
        operations.
 
        The default setting returns the differences between the original 


### PR DESCRIPTION
## Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-21735

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=624af2e92e8f69777c5529d8

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-21735/configuration/read/#change-streams

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
