### PR TITLE
DOCSP-21884 updated config uri name

### DIFF
--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -343,7 +343,7 @@ Change Streams
 .. _configure-input-uri:
 
 ``connection.uri`` Configuration Setting
------------------------------
+----------------------------------------
 
 You can set all :ref:`spark-input-conf` via the read ``connection.uri`` setting.
 

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -31,14 +31,14 @@ You can configure the following properties to read from MongoDB:
    * - Property name
      - Description
 
-   * - ``uri``
+   * - ``connection.uri``
      - **Required.**
        The connection string in the form
        ``mongodb://host:port/``. The ``host`` can be a hostname, IP
        address, or UNIX domain socket. If the connection string doesn't
        specify a ``port``, it uses the default MongoDB port, ``27017``.
 
-       You can append the other remaining read options to the ``uri``
+       You can append the other remaining read options to the ``connection.uri``
        setting. See :ref:`configure-input-uri`.
 
    * - ``database``
@@ -342,13 +342,13 @@ Change Streams
 
 .. _configure-input-uri:
 
-``uri`` Configuration Setting
+``connection.uri`` Configuration Setting
 -----------------------------
 
-You can set all :ref:`spark-input-conf` via the read ``uri`` setting.
+You can set all :ref:`spark-input-conf` via the read ``connection.uri`` setting.
 
 For example, consider the following example which sets the read
-``uri`` setting via ``SparkConf``:
+``connection.uri`` setting via ``SparkConf``:
 
 .. note::
 
@@ -357,24 +357,24 @@ For example, consider the following example which sets the read
 
 .. code:: cfg
 
-   spark.mongodb.read.uri=mongodb://127.0.0.1/databaseName.collectionName?readPreference=primaryPreferred
+  spark.mongodb.read.connection.uri=mongodb://127.0.0.1/databaseName.collectionName?readPreference=primaryPreferred
 
 The configuration corresponds to the following separate configuration
 settings:
 
 .. code:: cfg
 
-   spark.mongodb.read.uri=mongodb://127.0.0.1/
+  spark.mongodb.read.connection.uri=mongodb://127.0.0.1/
    spark.mongodb.read.database=databaseName
    spark.mongodb.read.collection=collectionName
    spark.mongodb.read.readPreference.name=primaryPreferred
 
-If you specify a setting both in the ``uri`` and in a separate
-configuration, the ``uri`` setting overrides the separate
+If you specify a setting both in the ``connection.uri`` and in a separate
+configuration, the ``connection.uri`` setting overrides the separate
 setting. For example, given the following configuration, the
 database for the connection is ``foobar``:
 
 .. code:: cfg
 
-   spark.mongodb.read.uri=mongodb://127.0.0.1/foobar
+  spark.mongodb.read.connection.uri=mongodb://127.0.0.1/foobar
    spark.mongodb.read.database=bar

--- a/source/configuration/write.txt
+++ b/source/configuration/write.txt
@@ -103,7 +103,7 @@ The following options for writing to MongoDB are available:
 .. _configure-output-uri:
 
 ``connection.uri`` Configuration Setting
------------------------------
+----------------------------------------
 
 You can set all :ref:`spark-output-conf` via the write ``connection.uri``.
 

--- a/source/configuration/write.txt
+++ b/source/configuration/write.txt
@@ -31,7 +31,7 @@ The following options for writing to MongoDB are available:
    * - Property name
      - Description
 
-   * - ``uri``
+   * - ``connection.uri``
      - **Required.** 
        The connection string in the form
        ``mongodb://host:port/``. The ``host`` can be a hostname, IP
@@ -40,7 +40,7 @@ The following options for writing to MongoDB are available:
        
        .. note:: 
 
-          The other remaining options may be appended to the ``uri``
+          The other remaining options may be appended to the ``connection.uri``
           setting. See :ref:`configure-output-uri`.
 
    * - ``database``
@@ -102,13 +102,13 @@ The following options for writing to MongoDB are available:
 
 .. _configure-output-uri:
 
-``uri`` Configuration Setting
+``connection.uri`` Configuration Setting
 -----------------------------
 
-You can set all :ref:`spark-output-conf` via the write ``uri``.
+You can set all :ref:`spark-output-conf` via the write ``connection.uri``.
 
 For example, consider the following example which sets the write
-``uri`` setting via ``SparkConf``:
+``connection.uri`` setting via ``SparkConf``:
 
 .. note::
 
@@ -117,23 +117,23 @@ For example, consider the following example which sets the write
 
 .. code:: cfg
 
-   spark.mongodb.write.uri=mongodb://127.0.0.1/test.myCollection
+  spark.mongodb.write.connection.uri=mongodb://127.0.0.1/test.myCollection
 
 The configuration corresponds to the following separate configuration
 settings:
 
 .. code:: cfg
 
-   spark.mongodb.write.uri=mongodb://127.0.0.1/
+  spark.mongodb.write.connection.uri=mongodb://127.0.0.1/
    spark.mongodb.write.database=test
    spark.mongodb.write.collection=myCollection
 
-If you specify a setting both in the ``uri`` and in a separate
-configuration, the ``uri`` setting overrides the separate
+If you specify a setting both in the ``connection.uri`` and in a separate
+configuration, the ``connection.uri`` setting overrides the separate
 setting. For example, given the following configuration, the
 database for the connection is ``foobar``:
 
 .. code:: cfg
 
-   spark.mongodb.write.uri=mongodb://127.0.0.1/foobar
+  spark.mongodb.write.connection.uri=mongodb://127.0.0.1/foobar
    spark.mongodb.write.database=bar

--- a/source/includes/extracts-command-line.yaml
+++ b/source/includes/extracts-command-line.yaml
@@ -17,11 +17,11 @@ content: |
 ---
 ref: list-configuration-explanation
 content: |
-   - The :ref:`spark.mongodb.read.uri <spark-input-conf>` specifies the
+   - The :ref:`spark.mongodb.read.connection.uri <spark-input-conf>` specifies the
      MongoDB server address (``127.0.0.1``), the database to connect
      (``test``), and the collection (``myCollection``) from which to read
      data, and the read preference.
-   - The :ref:`spark.mongodb.write.uri <spark-output-conf>` specifies the
+   - The :ref:`spark.mongodb.write.connection.uri <spark-output-conf>` specifies the
      MongoDB server address (``127.0.0.1``), the database to connect
      (``test``), and the collection (``myCollection``) to which to write
      data. Connects to port ``27017`` by default.
@@ -37,8 +37,8 @@ content: |
 
    .. code-block:: sh
 
-      ./bin/spark-shell --conf "spark.mongodb.read.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
-                        --conf "spark.mongodb.write.uri=mongodb://127.0.0.1/test.myCollection" \
+      ./bin/spark-shell --conf "spark.mongodb.read.connection.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
+                        --conf "spark.mongodb.write.connection.uri=mongodb://127.0.0.1/test.myCollection" \
                         --packages org.mongodb.spark:mongo-spark-connector:{+current-version+}
  
    .. include:: /includes/extracts/list-configuration-explanation.rst
@@ -54,8 +54,8 @@ content: |
 
    .. code-block:: sh
 
-      ./bin/pyspark --conf "spark.mongodb.read.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
-                    --conf "spark.mongodb.write.uri=mongodb://127.0.0.1/test.myCollection" \
+      ./bin/pyspark --conf "spark.mongodb.read.connection.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
+                    --conf "spark.mongodb.write.connection.uri=mongodb://127.0.0.1/test.myCollection" \
                     --packages org.mongodb.spark:mongo-spark-connector:{+current-version+}
  
    .. include:: /includes/extracts/list-configuration-explanation.rst
@@ -71,8 +71,8 @@ content: |
 
    .. code-block:: sh
 
-      ./bin/sparkR  --conf "spark.mongodb.read.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
-                    --conf "spark.mongodb.write.uri=mongodb://127.0.0.1/test.myCollection" \
+      ./bin/sparkR  --conf "spark.mongodb.read.connection.uri=mongodb://127.0.0.1/test.myCollection?readPreference=primaryPreferred" \
+                    --conf "spark.mongodb.write.connection.uri=mongodb://127.0.0.1/test.myCollection" \
                     --packages org.mongodb.spark:mongo-spark-connector:{+current-version+}
 
    .. include:: /includes/extracts/list-configuration-explanation.rst

--- a/source/java/api.txt
+++ b/source/java/api.txt
@@ -48,8 +48,8 @@ Configuration
        SparkSession spark = SparkSession.builder()
          .master("local")
          .appName("MongoSparkConnectorIntro")
-         .config("spark.mongodb.read.uri", "mongodb://127.0.0.1/test.myCollection")
-         .config("spark.mongodb.write.uri", "mongodb://127.0.0.1/test.myCollection")
+         .config("spark.mongodb.read.connection.uri", "mongodb://127.0.0.1/test.myCollection")
+         .config("spark.mongodb.write.connection.uri", "mongodb://127.0.0.1/test.myCollection")
          .getOrCreate();
        
        // Application logic
@@ -57,12 +57,12 @@ Configuration
      }
    }
    
-- The :ref:`spark.mongodb.read.uri <spark-input-conf>` specifies the
+- The :ref:`spark.mongodb.read.connection.uri <spark-input-conf>` specifies the
   MongoDB server  address(``127.0.0.1``), the database to connect
   (``test``), and the collection (``myCollection``) from which to read
   data, and the read preference.
 
-- The :ref:`spark.mongodb.write.uri <spark-output-conf>` specifies the
+- The :ref:`spark.mongodb.write.connection.uri <spark-output-conf>` specifies the
   MongoDB server address(``127.0.0.1``), the database to connect
   (``test``), and the collection (``myCollection``) to which to write
   data.

--- a/source/python/api.txt
+++ b/source/python/api.txt
@@ -19,8 +19,8 @@ Create a ``SparkSession`` Object
    ``spark`` by default. In a standalone Python application, you need
    to create your ``SparkSession`` object explicitly, as show below.
    
-If you specified the ``spark.mongodb.read.uri``
-and ``spark.mongodb.write.uri`` configuration options when you
+If you specified the ``spark.mongodb.read.connection.uri``
+and ``spark.mongodb.write.connection.uri`` configuration options when you
 started ``pyspark``, the default ``SparkSession`` object uses them.
 If you'd rather create your own ``SparkSession`` object from within
 ``pyspark``, you can use ``SparkSession.builder`` and specify different
@@ -33,8 +33,8 @@ configuration options.
    my_spark = SparkSession \
        .builder \
        .appName("myApp") \
-       .config("spark.mongodb.read.uri", "mongodb://127.0.0.1/test.coll") \
-       .config("spark.mongodb.write.uri", "mongodb://127.0.0.1/test.coll") \
+       .config("spark.mongodb.read.connection.uri", "mongodb://127.0.0.1/test.coll") \
+       .config("spark.mongodb.write.connection.uri", "mongodb://127.0.0.1/test.coll") \
        .getOrCreate()
 
 You can use a ``SparkSession`` object to write data to MongoDB, read

--- a/source/python/read-from-mongodb.txt
+++ b/source/python/read-from-mongodb.txt
@@ -1,6 +1,6 @@
 You can create a Spark DataFrame to hold data from the MongoDB
 collection specified in the
-:ref:`spark.mongodb.read.uri <pyspark-shell>` option which your
+:ref:`spark.mongodb.read.connection.uri <pyspark-shell>` option which your
 ``SparkSession`` option is using.
 
 .. include:: /includes/example-load-dataframe.rst

--- a/source/python/write-to-mongodb.txt
+++ b/source/python/write-to-mongodb.txt
@@ -9,7 +9,7 @@ a list of tuples containing names and ages, and a list of column names:
       ("Dwalin", 169), ("Oin", 167), ("Gloin", 158), ("Fili", 82), ("Bombur", None)], ["name", "age"])
 
 Write the ``people`` DataFrame to the MongoDB database and collection
-specified in the :ref:`spark.mongodb.write.uri<pyspark-shell>` option
+specified in the :ref:`spark.mongodb.write.connection.uri<pyspark-shell>` option
 by using the ``write`` method:
 
 .. code-block:: python
@@ -17,7 +17,7 @@ by using the ``write`` method:
    people.write.format("mongodb").mode("append").save()
 
 The above operation writes to the MongoDB database and collection
-specified in the :ref:`spark.mongodb.write.uri<pyspark-shell>` option
+specified in the :ref:`spark.mongodb.write.connection.uri<pyspark-shell>` option
 when you connect to the ``pyspark`` shell.
 
 To read the contents of the DataFrame, use the ``show()`` method.

--- a/source/scala/api.txt
+++ b/source/scala/api.txt
@@ -69,8 +69,8 @@ Configuration
        val spark = SparkSession.builder()
          .master("local")
          .appName("MongoSparkConnectorIntro")
-         .config("spark.mongodb.read.uri", "mongodb://127.0.0.1/test.myCollection")
-         .config("spark.mongodb.write.uri", "mongodb://127.0.0.1/test.myCollection")
+         .config("spark.mongodb.read.connection.uri", "mongodb://127.0.0.1/test.myCollection")
+         .config("spark.mongodb.write.connection.uri", "mongodb://127.0.0.1/test.myCollection")
          .getOrCreate()
          
      }


### PR DESCRIPTION
## Pull Request Info

Updated `uri` -> `connection.uri`

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-21884

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62505dbd0fdfea9c377b239c

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-21884/configuration/write/

https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-21884/configuration/read/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
