### PR TITLE
Fix option name

### DIFF
--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -148,7 +148,7 @@ You can configure the following properties to read from MongoDB:
    * - ``sql.pipeline.includeFiltersAndProjections``
      - Includes any filters and projections in the aggregation pipeline.
 
-   * - ``pipeline``
+   * - ``aggregation.pipeline``
      - Enables you to apply custom aggregation pipelines to the collection
        before sending it to Spark.
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?

***

I tried to select only 5 records from mongo using `org.mongodb.spark:mongo-spark-connector:10.0.1` with the following code

```scala
val df = (
  spark
  .read
  .format("mongodb")
  .option("database", mongo_database)
  .option("collection", table)
  .option("connection.uri",  dbutils.secrets.get(mongo_database, "mongodb-uri"))
  .option("pipeline", "{'$limit': 5}")
  .load()
)
```

But it always return all the records in the collection. It seems that `pipeline` option is not in active. I read the [source code of the connector](https://github.com/mongodb/mongo-spark/blob/1303e9c6173a735a86ddcd57a5b36e1910bfcbfe/src/main/java/com/mongodb/spark/sql/connector/config/ReadConfig.java#L142), and I found that the name of the option should be `aggregation.pipeline`.

Once I change the option to `aggregation.pipeline`, then the df only contains 5 records.

```scala
val df = (
  spark
  .read
  .format("mongodb")
  .option("database", mongo_database)
  .option("collection", table)
  .option("connection.uri",  dbutils.secrets.get(mongo_database, "mongodb-uri"))
  .option("aggregation.pipeline", "{'$limit': 5}")
  .load()
)
```

This PR fixes the option in the docs.



