### PR TITLE
DOCS-15666: fix read config admonition

### DIFF
--- a/source/includes/sparkconf-partitioner-options-note.rst
+++ b/source/includes/sparkconf-partitioner-options-note.rst
@@ -1,5 +1,5 @@
 .. note::
 
    If you use ``SparkConf`` to set the connector's read configurations, prefix
-   each property with ``spark.mongodb.read.partitionerOptions.`` instead of
+   each property with ``spark.mongodb.read.partitioner.options.`` instead of
    ``partitioner.options.``.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

Note: this PR is on the v10.0 branch as the main branch is currently out of sync with v10.0. See [this ticket](https://jira.mongodb.org/browse/DOCSP-25732) for more info.

JIRA - <https://jira.mongodb.org/browse/DOCS-15666>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCS-15666-fix-read-config-admonition/configuration/read/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
