### PR TITLE
Fix code block indentation

### DIFF
--- a/source/java/sql.txt
+++ b/source/java/sql.txt
@@ -4,9 +4,9 @@
 
 .. code-block:: java
 
-		implicitDS.createOrReplaceTempView("characters");
-		Dataset<Row> centenarians = spark.sql("SELECT name, age FROM characters WHERE age >= 100");
-		centenarians.show();
+   implicitDS.createOrReplaceTempView("characters");
+   Dataset<Row> centenarians = spark.sql("SELECT name, age FROM characters WHERE age >= 100");
+   centenarians.show();
 
 ``centenarians.show()`` outputs the following:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

No JIRA ticket

This PR fixes the code-block rST indentation which silently failed to apply syntax highlighting for the specified language. While it's beyond expectations to review each file, to verify the syntax highlighting is applied, you'll need to individually inspect each code block with Chrome Tools for the "java" (or other) style in the code component:

<img width="474" alt="Screen Shot 2022-11-10 at 12 56 30 AM" src="https://user-images.githubusercontent.com/52428683/201012014-cc6d6b5e-e5ea-4627-a870-4b875c298275.png">



Staging:

[SQL Queries](https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/110922-fix-code-block-indentation/read-from-mongodb/#sql-queries)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
