### PR TITLE
DOCSP-27521 - Fix Broken PySpark Links in v10.0

### DIFF
--- a/source/structured-streaming.txt
+++ b/source/structured-streaming.txt
@@ -94,8 +94,8 @@ Configuring a Write Stream to MongoDB
        content: |
 
          Specify write stream configuration settings on your streaming 
-         DataFrame using `DataStreamWriter <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.html>`__. You 
-         must specify the following configuration settings to write 
+         DataFrame using `DataStreamWriter <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.html>`__. 
+         You must specify the following configuration settings to write 
          to MongoDB:
          
          .. list-table::
@@ -125,7 +125,7 @@ Configuring a Write Stream to MongoDB
             * - ``writeStream.outputMode()``
               - Specifies how data of a streaming DataFrame is 
                 written to a streaming sink. To view a list of all 
-                supported output modes, see `the pyspark outputMode documentation <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__.
+                supported output modes, see `the pyspark outputMode documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__.
 
          
          The following code snippet shows how to use the preceding 
@@ -143,7 +143,7 @@ Configuring a Write Stream to MongoDB
               .outputMode("append")
 
          For a complete list of methods, see the 
-         `pyspark Structured Streaming reference <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.html#pyspark.sql.streaming.DataStreamWriter>`__.
+         `pyspark Structured Streaming reference <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.html#pyspark.sql.streaming.DataStreamWriter>`__.
 
      - id: scala
        content: |
@@ -290,8 +290,8 @@ more about continuous processing, see the `Spark documentation <https://spark.ap
          .. include:: /includes/fact-read-from-change-stream
          
          Specify read stream configuration settings on 
-         `DataStreamReader <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamReader.html>`__. You must specify the following 
-         configuration settings to read from MongoDB:
+         `DataStreamReader <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamReader.html>`__.
+         You must specify the following configuration settings to read from MongoDB:
          
          .. list-table::
             :header-rows: 1
@@ -307,7 +307,7 @@ more about continuous processing, see the `Spark documentation <https://spark.ap
             * - ``writeStream.trigger()``
               - The policy that indicates how often results should be 
                 written to the streaming sink. To view a list of all 
-                supported policies, see `the pyspark trigger documentation <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.trigger.html#pyspark.sql.streaming.DataStreamWriter.trigger>`__.
+                supported policies, see `the pyspark trigger documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.trigger.html#pyspark.sql.streaming.DataStreamWriter.trigger>`__.
 
                 When set, this method enables continuous processing 
                 for your read stream. Pass the method a time value 
@@ -341,7 +341,7 @@ more about continuous processing, see the `Spark documentation <https://spark.ap
             ``start()`` method on a streaming query.
 
          For a complete list of methods, see the 
-         `pyspark Structured Streaming reference <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamReader.html>`__.
+         `pyspark Structured Streaming reference <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamReader.html>`__.
 
      - id: scala
        content: |
@@ -477,11 +477,11 @@ To stream data from a CSV file to MongoDB:
        content: |
 
          1. Create a 
-            `DataStreamReader <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamReader.html>`__ 
+            `DataStreamReader <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamReader.html>`__
             that reads from the CSV file.
 
          #. Create a 
-            `DataStreamWriter <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.html>`__
+            `DataStreamWriter <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.html>`__
             by calling the ``writeStream()`` method on the streaming 
             DataFrame that you created with a ``DataStreamReader``. 
             Specify the format ``mongodb`` using the ``format()`` method.
@@ -490,7 +490,7 @@ To stream data from a CSV file to MongoDB:
             instance to begin the stream.
          
          As the connector reads data from the CSV file, it adds that 
-         data to MongoDB using the `outputMode <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__ 
+         data to MongoDB using the `outputMode <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__
          you specify.
 
          .. code-block:: python
@@ -643,11 +643,11 @@ To stream data from MongoDB to your console:
        content: |
 
          1. Create a 
-            `DataStreamReader <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamReader.html>`__ 
+            `DataStreamReader <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamReader.html>`__ 
             that reads from MongoDB.
 
          #. Create a 
-            `DataStreamWriter <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.html>`__
+            `DataStreamWriter <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.html>`__
             by calling the ``writeStream()`` method on the streaming 
             DataFrame that you created with a ``DataStreamReader``. 
             Specify the format ``console`` using the ``format()`` method.
@@ -656,7 +656,7 @@ To stream data from MongoDB to your console:
             instance to begin the stream.
          
          As new data is inserted into MongoDB, MongoDB streams that 
-         data out to your console using the `outputMode <https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__ 
+         data out to your console using the `outputMode <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__ 
          you specify.
 
          .. include:: /includes/warn-console-stream.txt

--- a/source/structured-streaming.txt
+++ b/source/structured-streaming.txt
@@ -41,7 +41,8 @@ Configuring a Write Stream to MongoDB
        content: |
 
          Specify write stream configuration settings on your streaming 
-         Dataset or streaming DataFrame using `DataStreamWriter <https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/streaming/DataStreamWriter.html>`__. You must specify the following configuration 
+         Dataset or streaming DataFrame using `DataStreamWriter <https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/streaming/DataStreamWriter.html>`__. 
+         You must specify the following configuration 
          settings to write to MongoDB:
          
          .. list-table::
@@ -125,7 +126,7 @@ Configuring a Write Stream to MongoDB
             * - ``writeStream.outputMode()``
               - Specifies how data of a streaming DataFrame is 
                 written to a streaming sink. To view a list of all 
-                supported output modes, see `the pyspark outputMode documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__.
+                supported output modes, see the `pyspark outputMode documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.outputMode.html#pyspark.sql.streaming.DataStreamWriter.outputMode>`__.
 
          
          The following code snippet shows how to use the preceding 
@@ -307,7 +308,7 @@ more about continuous processing, see the `Spark documentation <https://spark.ap
             * - ``writeStream.trigger()``
               - The policy that indicates how often results should be 
                 written to the streaming sink. To view a list of all 
-                supported policies, see `the pyspark trigger documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.trigger.html#pyspark.sql.streaming.DataStreamWriter.trigger>`__.
+                supported policies, see the `pyspark trigger documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.trigger.html#pyspark.sql.streaming.DataStreamWriter.trigger>`__.
 
                 When set, this method enables continuous processing 
                 for your read stream. Pass the method a time value 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-27521
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/v10.0/structured-streaming/

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [X] Are all the links working?
