### PR TITLE
DOCSP-29697 - fix variable name

### DIFF
--- a/source/java/write-to-mongodb.txt
+++ b/source/java/write-to-mongodb.txt
@@ -34,7 +34,7 @@ Write to MongoDB
        JavaSparkContext jsc = new JavaSparkContext(spark.sparkContext());
          
        // Create a RDD of 10 documents
-       JavaRDD<Document> documents = jsc.parallelize(asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).map
+       JavaRDD<Document> sparkDocuments = jsc.parallelize(asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).map
                (new Function<Integer, Document>() {
          public Document call(final Integer i) throws Exception {
              return Document.parse("{test: " + i + "}");


### PR DESCRIPTION
Note: This PR is merging to v3.0 and being backported to versions before that. This fix isn't applicable in versions after 3.0.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-29697
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/docsp-29697-variable-name/java/write-to-mongodb/

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
