### PR TITLE
DOCSP-30376: Clarified streaming produces a single partition

### DIFF
--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -134,8 +134,8 @@ Partitioner Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Partitioners change the read behavior for batch reads with the {+driver-short+}.
-They have no effect on structured streams because structured streams only
-produce a single stream.
+They do not affect Structured Streaming because the data stream processing
+engine produces a single stream with Structured Streaming.
 
 This section contains configuration information for the following 
 partitioners:

--- a/source/configuration/read.txt
+++ b/source/configuration/read.txt
@@ -133,6 +133,10 @@ You can configure the following properties to read from MongoDB:
 Partitioner Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Partitioners change the read behavior for batch reads with the {+driver-short+}.
+They have no effect on structured streams because structured streams only
+produce a single stream.
+
 This section contains configuration information for the following 
 partitioners:
 

--- a/source/structured-streaming.txt
+++ b/source/structured-streaming.txt
@@ -202,10 +202,10 @@ more about continuous processing, see the `Spark documentation <https://spark.ap
 
 .. note::
 
-    Since structured streaming produces a single partition,
-    :ref:`partitioner configurations <partitioner-conf>` do not change the
-    behavior of read streams. This is true for both micro-batch processing and
-    continuous processing streams.
+    Since Structured Streaming produces a single partition, it ignores
+    :ref:`partitioner configurations <partitioner-conf>`. Partitioner
+    configuration only apply when there are multiple partitions. This is true
+    for both micro-batch processing and continuous processing streams.
 
 .. tabs-drivers::
 

--- a/source/structured-streaming.txt
+++ b/source/structured-streaming.txt
@@ -200,6 +200,13 @@ more about continuous processing, see the `Spark documentation <https://spark.ap
 
 .. include:: /includes/fact-read-from-change-stream
 
+.. note::
+
+    Since structured streaming produces a single partition,
+    :ref:`partitioner configurations <partitioner-conf>` do not change the
+    behavior of read streams. This is true for both micro-batch processing and
+    continuous processing streams.
+
 .. tabs-drivers::
 
    tabs:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-30376>
Staging - 
   * Structured streaming: https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-30376/structured-streaming/#configuring-a-read-stream-from-mongodb
   * Partition configurations: https://docs-mongodbcom-staging.corp.mongodb.com/spark-connector/docsworker-xlarge/DOCSP-30376/configuration/read/#partitioner-configurations

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST? (I believe these errors are expected)
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
