### PR TITLE
add links to content of the API documentation page

### DIFF
--- a/source/api-docs.txt
+++ b/source/api-docs.txt
@@ -2,6 +2,9 @@
 API Documentation
 =================
 
+- `Spark Connector for Scala 2.13 <https://www.javadoc.io/doc/org.mongodb.spark/{+artifact-id-2-13+}/{+current-version+}/index.html>`__
+- `Spark Connector for Scala 2.12 <https://www.javadoc.io/doc/org.mongodb.spark/{+artifact-id-2-12+}/{+current-version+}/index.html>`__
+
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

Surfaces links contained within the section in case the reader navigates directly to the API page. Another solution could be to eliminate the ToC so that the links only show up in the content of the API documentation page.

JIRA - None
Staging - [API Documentation](https://preview-mongodbcchomongodb.gatsbyjs.io/spark-connector/101023-add-api-docs-links/api-docs/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
