### PR TITLE
DOCSP-31790 update title to alphabetize legacy product menu

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "spark-connector"
-title = "MongoDB Spark Connector"
+title = "Spark Connector"
 
 intersphinx = ["https://www.mongodb.com/docs/manual/objects.inv"]
 


### PR DESCRIPTION
Hey @caitlindavey!

Here's the PR for renaming the Kafka Connector title field in the snooty.toml files so that DOP can set up the legacy menu to pull from that field. Please backport to older versions if we're good to go.

This changes two elements on the page: the top level on the level nav and the breadcrumb verbiage. Spark Connector is how it's listed on the Tools & Migrators page, and "MongoDB" is redundant (we can't have everything alphabetized under M).

Here's my[ build log ](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=653a98493ede3ec1116074b5).

Thanks for your review & merge!
Sarah

# Pull Request Info
JIRA - <https://jira.mongodb.org/browse/DOCSP-31790>
Staging - <https://preview-mongodbsarahemlin.gatsbyjs.io/spark-connector/DOCSP-31790/>