### PR TITLE
DOCSP-42969 - Remove nested admonitions

### DIFF
--- a/source/includes/note-trigger-method.rst
+++ b/source/includes/note-trigger-method.rst
@@ -1,4 +1,0 @@
-.. note::
-
-   Call the ``trigger()`` method on the ``DataStreamWriter`` you create 
-   from the ``DataStreamReader`` you configure.

--- a/source/streaming-mode/streaming-read-config.txt
+++ b/source/streaming-mode/streaming-read-config.txt
@@ -82,12 +82,10 @@ You can configure the following properties when reading data from MongoDB in str
 
           [{"$match": {"closed": false}}, {"$project": {"status": 1, "name": 1, "description": 1}}]
 
-       .. important::
-
-          Custom aggregation pipelines must be compatible with the
-          partitioner strategy. For example, aggregation stages such as
-          ``$group`` do not work with any partitioner that creates more than
-          one partition.
+       Custom aggregation pipelines must be compatible with the
+       partitioner strategy. For example, aggregation stages such as
+       ``$group`` do not work with any partitioner that creates more than
+       one partition.
 
    * - ``aggregation.allowDiskUse``
      - | Specifies whether to allow storage to disk when running the
@@ -135,13 +133,11 @@ You can configure the following properties when reading a change stream from Mon
        original document and updated document, but it also includes a copy of the
        entire updated document.
 
+       For more information on how this change stream option works,
+       see the MongoDB server manual guide
+       :manual:`Lookup Full Document for Update Operation </changeStreams/#lookup-full-document-for-update-operations>`.
+       
        **Default:** "default"
-
-       .. tip::
-
-          For more information on how this change stream option works,
-          see the MongoDB server manual guide
-          :manual:`Lookup Full Document for Update Operation </changeStreams/#lookup-full-document-for-update-operations>`.
 
    * - ``change.stream.micro.batch.max.partition.count``
      - | The maximum number of partitions the {+connector-short+} divides each 
@@ -151,11 +147,9 @@ You can configure the following properties when reading a change stream from Mon
        |
        | **Default**: ``1``
 
-       .. warning:: Event Order
-
-          Specifying a value larger than ``1`` can alter the order in which
-          the {+connector-short+} processes change events. Avoid this setting
-          if out-of-order processing could create data inconsistencies downstream. 
+       :red:`WARNING:` Specifying a value larger than ``1`` can alter the order in which
+       the {+connector-short+} processes change events. Avoid this setting
+       if out-of-order processing could create data inconsistencies downstream. 
 
    * - ``change.stream.publish.full.document.only``
      - | Specifies whether to publish the changed document or the full
@@ -174,12 +168,10 @@ You can configure the following properties when reading a change stream from Mon
        - If you don't specify a schema, the connector infers the schema
          from the change stream document.
 
-       **Default**: ``false``
+       This setting overrides the ``change.stream.lookup.full.document``
+       setting.
        
-       .. note::
-
-          This setting overrides the ``change.stream.lookup.full.document``
-          setting.
+       **Default**: ``false``
 
    * - ``change.stream.startup.mode``
      - | Specifies how the connector starts up when no offset is available.

--- a/source/streaming-mode/streaming-write.txt
+++ b/source/streaming-mode/streaming-write.txt
@@ -51,7 +51,8 @@ Write to MongoDB in Streaming Mode
  
             * - ``writeStream.trigger()``
               - Specifies how often the {+connector-short+} writes results
-                to the streaming sink. 
+                to the streaming sink. Call this method on the ``DataStreamWriter`` object
+                you create from the ``DataStreamReader`` you configure.
                 
                 To use continuous processing, pass ``Trigger.Continuous(<time value>)`` 
                 as an argument, where ``<time value>`` is how often you want the Spark
@@ -62,8 +63,6 @@ Write to MongoDB in Streaming Mode
   
                 To view a list of all supported processing policies, see the `Java 
                 trigger documentation <https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/streaming/Trigger.html>`__.
-
-                .. include:: /includes/note-trigger-method
         
          The following code snippet shows how to use the previous 
          configuration settings to stream data to MongoDB:
@@ -119,7 +118,8 @@ Write to MongoDB in Streaming Mode
 
             * - ``writeStream.trigger()``
               - Specifies how often the {+connector-short+} writes results
-                to the streaming sink. 
+                to the streaming sink. Call this method on the ``DataStreamWriter`` object
+                you create from the ``DataStreamReader`` you configure.
 
                 To use continuous processing, pass the function a time value 
                 using the ``continuous`` parameter.
@@ -130,8 +130,6 @@ Write to MongoDB in Streaming Mode
                 To view a list of all supported processing policies, see 
                 the `pyspark trigger documentation <https://spark.apache.org/docs/latest/api/python/reference/pyspark.ss/api/pyspark.sql.streaming.DataStreamWriter.trigger.html>`__.
 
-                .. include:: /includes/note-trigger-method
-         
          The following code snippet shows how to use the previous 
          configuration settings to stream data to MongoDB:
 
@@ -186,7 +184,8 @@ Write to MongoDB in Streaming Mode
  
             * - ``writeStream.trigger()``
               - Specifies how often the {+connector-short+} writes results
-                to the streaming sink.
+                to the streaming sink. Call this method on the ``DataStreamWriter`` object
+                you create from the ``DataStreamReader`` you configure.
 
                 To use continuous processing, pass ``Trigger.Continuous(<time value>)`` 
                 as an argument, where ``<time value>`` is how often you want the Spark
@@ -198,8 +197,6 @@ Write to MongoDB in Streaming Mode
                 To view a list of all 
                 supported processing policies, see the `Scala trigger documentation <https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/streaming/DataStreamWriter.html#trigger(trigger:org.apache.spark.sql.streaming.Trigger):org.apache.spark.sql.streaming.DataStreamWriter[T]>`__.
 
-                .. include:: /includes/note-trigger-method
-        
          The following code snippet shows how to use the previous 
          configuration settings to stream data to MongoDB:
 


### PR DESCRIPTION
Removed nested admonitions following [this doc](https://docs.google.com/document/d/1yMbng-EPOQ82bAzBTC2VJwIvsUBOSCJh21cGbDoe1a8/edit#heading=h.8t0xo8i29om4)

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-42969
Staging:
- https://preview-mongodbmongokart.gatsbyjs.io/spark-connector/docsp-42969-nested-components/batch-mode/batch-read-config/
- https://preview-mongodbmongokart.gatsbyjs.io/spark-connector/docsp-42969-nested-components/streaming-mode/streaming-read-config/
- https://preview-mongodbmongokart.gatsbyjs.io/spark-connector/docsp-42969-nested-components/streaming-mode/streaming-write/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
