### PR TITLE
(DOCSP-45749) Denests last phase 1 nested component for spark connector

### DIFF
--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -139,12 +139,11 @@ You can configure the following properties when reading data from MongoDB in bat
 
           [{"$match": {"closed": false}}, {"$project": {"status": 1, "name": 1, "description": 1}}]
 
-       .. important::
-
-          Custom aggregation pipelines must be compatible with the
-          partitioner strategy. For example, aggregation stages such as
-          ``$group`` do not work with any partitioner that creates more than
-          one partition.
+       :gold:`IMPORTANT:` Custom aggregation pipelines must be
+       compatible with the partitioner strategy. For example,
+       aggregation stages such as
+       ``$group`` do not work with any partitioner that creates more
+       than one partition.
 
    * - ``aggregation.allowDiskUse``
      - | Specifies whether to allow storage to disk when running the


### PR DESCRIPTION
# Pull Request Info

No content changes other than denesting nested admonition.

The build is clean, but there's a failing check to "check autobuilder for errors" due to autobuilder not being set up-- this is no longer relevant since we use Netlify for builds.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-45749
Staging - https://deploy-preview-220--docs-spark-connector.netlify.app/batch-mode/batch-read-config/#overview

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
