### PR TITLE
Backports DOCSP-45749 to v10.4

### DIFF
--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -139,12 +139,11 @@ You can configure the following properties when reading data from MongoDB in bat
 
           [{"$match": {"closed": false}}, {"$project": {"status": 1, "name": 1, "description": 1}}]
 
-       .. important::
-
-          Custom aggregation pipelines must be compatible with the
-          partitioner strategy. For example, aggregation stages such as
-          ``$group`` do not work with any partitioner that creates more than
-          one partition.
+       :gold:`IMPORTANT:` Custom aggregation pipelines must be
+       compatible with the partitioner strategy. For example,
+       aggregation stages such as
+       ``$group`` do not work with any partitioner that creates more
+       than one partition.
 
    * - ``aggregation.allowDiskUse``
      - | Specifies whether to allow storage to disk when running the


### PR DESCRIPTION
Backports #220
Build is clean, autobuilder failed check is due to autobuilder not being set up (no longer relevant)