### PR TITLE
[v10.3] DOCSP-31186 Add sections for connections (#243)

### DIFF
--- a/.github/workflows/vale-tdbx.yml
+++ b/.github/workflows/vale-tdbx.yml
@@ -18,20 +18,20 @@ jobs:
       - id: files
         uses: masesgroup/retrieve-changed-files@v2
         with:
-          format: 'csv'
+          format: "csv"
 
       - name: checkout-latest-rules
         uses: actions/checkout@master
         with:
           repository: mongodb/mongodb-vale-action
-          path: './tdbx-vale-rules'
+          path: "./tdbx-vale-rules"
           token: ${{secrets.GITHUB_TOKEN}}
 
       - name: move-files-for-vale-action
         run: |
-            cp tdbx-vale-rules/.vale.ini .vale.ini
-            mkdir -p .github/styles/
-            cp -rf tdbx-vale-rules/.github/styles/ .github/
+          cp tdbx-vale-rules/.vale.ini .vale.ini
+          mkdir -p .github/styles/
+          cp -rf tdbx-vale-rules/.github/styles/ .github/
 
       - name: run-vale
         uses: errata-ai/vale-action@reviewdog

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -45,6 +45,38 @@ Getting Started
 
          .. include:: /scala/api.rst
 
+Integrations
+------------
+
+The following sections describe some popular third-party platforms that you can
+integrate Spark and the {+connector-long+} with.
+
+Amazon EMR
+~~~~~~~~~~
+
+Amazon EMR is a managed cluster platform that you can use to run big data frameworks like Spark. To install Spark on an EMR cluster, see
+`Getting Started with Amazon EMR <https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-gs.html>`__ in the AWS documentation.
+
+Databricks
+~~~~~~~~~~
+
+Databricks is an analytics platform for building, deploying, and sharing enterprise-level data. To integrate the {+connector-long+} with Databricks,
+see `MongoDB <https://docs.databricks.com/aws/en/connect/external-systems/mongodb>`__ in the Databricks documentation.
+
+Docker
+~~~~~~
+
+Docker is an open-source platform that helps developers build, share, and run applications in containers. 
+
+- To start Spark in a Docker container, see `Apache Spark <https://hub.docker.com/r/apache/spark#!>`__ in the Docker documentation and follow the steps provided. 
+- To learn how to deploy Atlas on Docker, see `Create a Local Atlas Deployment with Docker <https://www.mongodb.com/docs/atlas/cli/current/atlas-cli-deploy-docker/>`__.
+
+Kubernetes
+~~~~~~~~~~
+
+Kubernetes is an open-source platform for automating containerization management. To run Spark on Kubernetes,
+see `Running Spark on Kubernetes <https://spark.apache.org/docs/3.5.4/running-on-kubernetes.html>`__ in the Spark documentation.
+
 Tutorials
 ---------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v10.3`:
 - [DOCSP-31186 Add sections for connections (#243)](https://github.com/mongodb/docs-spark-connector/pull/243)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)