### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/api-docs.txt
+++ b/source/api-docs.txt
@@ -2,6 +2,9 @@
 API Documentation
 =================
 
+.. meta::
+   :description: Explore API documentation for the Spark Connector compatible with Scala 2.13 and 2.12.
+
 - `Spark Connector for Scala 2.13 <https://www.javadoc.io/doc/org.mongodb.spark/{+artifact-id-2-13+}/{+current-version+}/index.html>`__
 - `Spark Connector for Scala 2.12 <https://www.javadoc.io/doc/org.mongodb.spark/{+artifact-id-2-12+}/{+current-version+}/index.html>`__
 

--- a/source/batch-mode.txt
+++ b/source/batch-mode.txt
@@ -2,6 +2,9 @@
 Batch Mode
 ==========
 
+.. meta::
+   :description: Explore how to use the Spark Connector to read and write data to MongoDB in batch mode using Spark's Dataset and DataFrame APIs.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -16,6 +16,7 @@ Batch Read Configuration Options
     
 .. meta::
    :keywords: partitioner, customize, settings 
+   :description: Configure batch read options for the Spark Connector, including connection URI, database, collection, and partitioner settings for efficient data processing.
 
 .. _spark-batch-input-conf:
 

--- a/source/batch-mode/batch-read.txt
+++ b/source/batch-mode/batch-read.txt
@@ -4,6 +4,9 @@
 Read from MongoDB in Batch Mode
 ===============================
 
+.. meta::
+   :description: Learn how to read data from MongoDB in batch mode using Spark, including configuration settings, schema inference, and applying filters for efficient data retrieval.
+
 .. toctree::
    :caption: Batch Read Configuration Options
 

--- a/source/batch-mode/batch-write-config.txt
+++ b/source/batch-mode/batch-write-config.txt
@@ -4,6 +4,9 @@
 Batch Write Configuration Options
 =================================
 
+.. meta::
+   :description: Configure batch write operations to MongoDB using various properties like connection URI, database, collection, and write concern options.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/batch-mode/batch-write.txt
+++ b/source/batch-mode/batch-write.txt
@@ -4,6 +4,9 @@
 Write to MongoDB in Batch Mode
 ==============================
 
+.. meta::
+   :description: Learn how to write data to MongoDB in batch mode using the Spark Connector, specifying format and configuration settings for Java, Python, and Scala.
+
 .. toctree::
    :caption: Batch Write Configuration Options
 

--- a/source/configuration.txt
+++ b/source/configuration.txt
@@ -4,6 +4,9 @@
 Configuring Spark
 =================
 
+.. meta::
+   :description: Configure read and write operations in Spark using `SparkConf`, options maps, or system properties for batch and streaming modes.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -2,6 +2,9 @@
 FAQ
 ===
 
+.. meta::
+   :description: Find solutions for achieving data locality, resolving pipeline stage errors, using mTLS for authentication, and sharing a MongoClient instance across threads with the Spark Connector.
+
 How can I achieve data locality?
 --------------------------------
 

--- a/source/getting-started.txt
+++ b/source/getting-started.txt
@@ -14,6 +14,7 @@ Getting Started with the {+connector-short+}
 
 .. meta::
    :keywords: quick start, tutorial, code example
+   :description: Get started with the Spark Connector by setting up dependencies, configuring connections, and integrating with platforms like Amazon EMR, Databricks, Docker, and Kubernetes.
 
 Prerequisites
 -------------

--- a/source/index.txt
+++ b/source/index.txt
@@ -2,6 +2,9 @@
 MongoDB Connector for Spark
 ===========================
 
+.. meta::
+   :description: Integrate MongoDB with Apache Spark using the MongoDB Connector for Spark, supporting Spark Structured Streaming.
+
 .. toctree::
    :titlesonly:
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,7 @@ Release Notes
 
 .. meta::
    :keywords: update, new feature, deprecation, breaking change
+   :description: Explore the latest features and changes in the MongoDB Connector for Spark, including updates for Java Sync Driver and support for multiple Spark versions.
 
 .. contents:: On this page
    :local:

--- a/source/streaming-mode.txt
+++ b/source/streaming-mode.txt
@@ -4,6 +4,9 @@
 Streaming Mode
 ==============
 
+.. meta::
+   :description: Explore how to use the Spark Connector for reading and writing data in streaming mode with Spark Structured Streaming.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/streaming-mode/streaming-read-config.txt
+++ b/source/streaming-mode/streaming-read-config.txt
@@ -16,6 +16,7 @@ Streaming Read Configuration Options
  
 .. meta::
    :keywords: change stream, customize
+   :description: Configure streaming read options for MongoDB in Spark, including connection settings, parsing strategies, and change stream configurations.
 
 .. _spark-streaming-input-conf:
 

--- a/source/streaming-mode/streaming-read.txt
+++ b/source/streaming-mode/streaming-read.txt
@@ -21,6 +21,7 @@ Read from MongoDB in Streaming Mode
  
 .. meta::
    :keywords: change stream
+   :description: Learn to read data from MongoDB in streaming mode using the Spark Connector, supporting micro-batch and continuous processing with configuration options.
 
 Overview
 --------

--- a/source/streaming-mode/streaming-write-config.txt
+++ b/source/streaming-mode/streaming-write-config.txt
@@ -4,6 +4,9 @@
 Streaming Write Configuration Options
 =====================================
 
+.. meta::
+   :description: Configure properties for writing data to MongoDB in streaming mode, including connection URI, database, collection, and checkpoint settings.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/streaming-mode/streaming-write.txt
+++ b/source/streaming-mode/streaming-write.txt
@@ -4,6 +4,9 @@
 Write to MongoDB in Streaming Mode
 ==================================
 
+.. meta::
+   :description: Learn to write data to MongoDB in streaming mode using Spark Connector with configuration settings for Java, Python, and Scala.
+
 .. toctree::
    :caption: Streaming Write Configuration Options
 

--- a/source/tls.txt
+++ b/source/tls.txt
@@ -16,6 +16,7 @@ Configure TLS/SSL
 
 .. meta::
    :keywords: code example, authenticate
+   :description: Learn how to configure TLS/SSL for secure communication between the Spark Connector and MongoDB, including setting up JVM trust and key stores.
 
 Overview
 --------


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539