### PR TITLE
[SPARK] Set Auto Bucket Partitioner to be the default partitioning strategy

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -21,6 +21,7 @@ artifact-id-2-13 = "mongo-spark-connector_2.13"
 artifact-id-2-12 = "mongo-spark-connector_2.12"
 spark-core-version = "3.3.1"
 spark-sql-version = "3.3.1"
+mdb-server = "MongoDB Server"
 
 [substitutions]
 copy = "unicode:: U+000A9"

--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -192,14 +192,15 @@ partitioner:
 
 .. _conf-autobucketpartitioner:
 
-``AutoBucketPartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+AutoBucketPartitioner Configuration (default)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``AutoBucketPartitioner`` is the default partitioner configuration and uses
+The ``AutoBucketPartitioner`` is the default partitioner configuration. It
+samples the data to generate partitions and uses
 the :manual:`$bucketAuto </reference/operator/aggregation/bucketAuto/>`
-aggregation stage to paginate the data. By using this configuration, 
-you can partition the data across single or multiple fields, including nested
-fields.
+aggregation stage to paginate data based on the the specified parameters. By
+using this configuration,  you can partition the data across single or multiple
+fields, including nested fields.
 
 .. note:: Compound Keys
 
@@ -246,13 +247,14 @@ To use this configuration, set the ``partitioner`` configuration option to
 .. _conf-mongosamplepartitioner:
 .. _conf-samplepartitioner:
 
-``SamplePartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SamplePartitioner Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``SamplePartitioner`` configuration configuration is similar to the
 :ref:`AutoBucketPartitioner <conf-autobucketpartitioner>`
-configuration, but does not use the ``$bucketAuto`` aggregation stage. This configuration lets you specify a partition field,
-partition size, and number of samples per partition. 
+configuration, but does not use the ``$bucketAuto`` aggregation stage. This
+configuration lets you specify a partition field, partition size, and number of
+samples per partition. 
 
 To use this configuration, set the ``partitioner`` configuration option to
 ``com.mongodb.spark.sql.connector.read.partitioner.SamplePartitioner``.
@@ -285,21 +287,11 @@ To use this configuration, set the ``partitioner`` configuration option to
 
        **Default:** ``10``
 
-.. example::
-
-   For a collection with 640 documents with an average document
-   size of 0.5 MB, the default ``SamplePartitioner`` configuration creates
-   5 partitions with 128 documents per partition.
-
-   The {+connector-short+} samples 50 documents (the default 10
-   per intended partition) and defines 5 partitions by selecting
-   partition field ranges from the sampled documents.
-
 .. _conf-mongoshardedpartitioner:
 .. _conf-shardedpartitioner:
 
-``ShardedPartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ShardedPartitioner Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``ShardedPartitioner`` configuration automatically partitions the data
 based on your shard configuration.
@@ -314,11 +306,21 @@ To use this configuration, set the ``partitioner`` configuration option to
       We do not recommend using the sharded partitioner when connected to MongoDB v6.0 and later.
    2. The sharded partitioner is not compatible with hashed shard keys.
 
+.. example::
+
+   For a collection with 640 documents with an average document
+   size of 0.5 MB, the default ``SamplePartitioner`` configuration creates
+   5 partitions with 128 documents per partition.
+
+   The {+connector-short+} samples 50 documents (the default 10
+   per intended partition) and defines 5 partitions by selecting
+   partition field ranges from the sampled documents.
+
 .. _conf-mongopaginatebysizepartitioner:
 .. _conf-paginatebysizepartitioner:
 
-``PaginateBySizePartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PaginateBySizePartitioner Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``PaginateBySizePartitioner`` configuration paginates the data by using the
 average document size to split the collection into average-sized chunks.
@@ -347,8 +349,8 @@ To use this configuration, set the ``partitioner`` configuration option to
 
 .. _conf-paginateintopartitionspartitioner:
 
-``PaginateIntoPartitionsPartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PaginateIntoPartitionsPartitioner Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``PaginateIntoPartitionsPartitioner`` configuration paginates the data by dividing
 the count of documents in the collection by the maximum number of allowable partitions.
@@ -375,15 +377,15 @@ To use this configuration, set the ``partitioner`` configuration option to
 
 .. _conf-singlepartitionpartitioner:
 
-``SinglePartitionPartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SinglePartitionPartitioner Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``SinglePartitionPartitioner`` configuration creates a single partition.
 
 To use this configuration, set the ``partitioner`` configuration option to
 ``com.mongodb.spark.sql.connector.read.partitioner.SinglePartitionPartitioner``.
 
-Specifying Properties in ``connection.uri``
--------------------------------------------
+Specifying Properties in connection.uri
+---------------------------------------
 
 .. include:: /includes/connection-read-config.rst

--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -7,7 +7,7 @@ Batch Read Configuration Options
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 .. facet::
@@ -178,17 +178,70 @@ dividing the data into partitions, you can run transformations in parallel.
 This section contains configuration information for the following 
 partitioner:
 
+- :ref:`AutoBucketPartitioner <conf-autobucketpartitioner>`
 - :ref:`SamplePartitioner <conf-samplepartitioner>`
 - :ref:`ShardedPartitioner <conf-shardedpartitioner>`
 - :ref:`PaginateBySizePartitioner <conf-paginatebysizepartitioner>`
 - :ref:`PaginateIntoPartitionsPartitioner <conf-paginateintopartitionspartitioner>`
 - :ref:`SinglePartitionPartitioner <conf-singlepartitionpartitioner>`
-- :ref:`AutoBucketPartitioner <conf-autobucketpartitioner>`
 
 .. note:: Batch Reads Only
   
    Because the data-stream-processing engine produces a single data stream,
    partitioners do not affect streaming reads.
+
+.. _conf-autobucketpartitioner:
+
+``AutoBucketPartitioner`` Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``AutoBucketPartitioner`` is the default partitioner configuration and uses
+the :manual:`$bucketAuto </reference/operator/aggregation/bucketAuto/>`
+aggregation stage to paginate the data. By using this configuration, 
+you can partition the data across single or multiple fields, including nested
+fields.
+
+.. note:: Compound Keys
+
+  The ``AutoBucketPartitioner`` configuration requires {+mdb-server+} version
+  7.0 or higher to support compound keys.
+
+To use this configuration, set the ``partitioner`` configuration option to
+``com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Property name
+     - Description
+     
+   * - ``partitioner.options.partition.fieldList``
+     - The list of fields to use for partitioning. The value can be either a single field
+       name or a list of comma-separated fields.
+      
+       **Default:** ``_id``
+
+   * - ``partitioner.options.partition.chunkSize``
+     - The average size (MB) for each partition. Smaller partition sizes
+       create more partitions containing fewer documents.
+       Because this configuration uses the average document size to determine the number of
+       documents per partition, partitions might not be the same size.
+      
+       **Default:** ``64``
+    
+   * - ``partitioner.options.partition.samplesPerPartition``
+     - The number of samples to take per partition.
+
+       **Default:** ``100``
+    
+   * - ``partitioner.options.partition.partitionKeyProjectionField``
+     - The field name to use for a projected field that contains all the
+       fields used to partition the collection.
+       We recommend changing the value of this property only if each document already
+       contains the ``__idx`` field.
+      
+       **Default:** ``__idx``
 
 .. _conf-mongosamplepartitioner:
 .. _conf-samplepartitioner:
@@ -196,8 +249,10 @@ partitioner:
 ``SamplePartitioner`` Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``SamplePartitioner`` is the default partitioner configuration. This configuration
-lets you specify a partition field, partition size, and number of samples per partition.
+The ``SamplePartitioner`` configuration configuration is similar to the
+:ref:`AutoBucketPartitioner <conf-autobucketpartitioner>`
+configuration, but does not use the ``$bucketAuto`` aggregation stage. This configuration lets you specify a partition field,
+partition size, and number of samples per partition. 
 
 To use this configuration, set the ``partitioner`` configuration option to
 ``com.mongodb.spark.sql.connector.read.partitioner.SamplePartitioner``.
@@ -327,54 +382,6 @@ The ``SinglePartitionPartitioner`` configuration creates a single partition.
 
 To use this configuration, set the ``partitioner`` configuration option to
 ``com.mongodb.spark.sql.connector.read.partitioner.SinglePartitionPartitioner``.
-
-.. _conf-autobucketpartitioner:
-
-``AutoBucketPartitioner`` Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``AutoBucketPartitioner`` configuration is similar to the
-:ref:`SamplePartitioner <conf-samplepartitioner>`
-configuration, but uses the :manual:`$bucketAuto </reference/operator/aggregation/bucketAuto/>`
-aggregation stage to paginate the data. By using this configuration, 
-you can partition the data across single or multiple fields, including nested fields.
-
-To use this configuration, set the ``partitioner`` configuration option to
-``com.mongodb.spark.sql.connector.read.partitioner.AutoBucketPartitioner``.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 35 65
-
-   * - Property name
-     - Description
-     
-   * - ``partitioner.options.partition.fieldList``
-     - The list of fields to use for partitioning. The value can be either a single field
-       name or a list of comma-separated fields.
-      
-       **Default:** ``_id``
-
-   * - ``partitioner.options.partition.chunkSize``
-     - The average size (MB) for each partition. Smaller partition sizes
-       create more partitions containing fewer documents.
-       Because this configuration uses the average document size to determine the number of
-       documents per partition, partitions might not be the same size.
-      
-       **Default:** ``64``
-    
-   * - ``partitioner.options.partition.samplesPerPartition``
-     - The number of samples to take per partition.
-
-       **Default:** ``100``
-    
-   * - ``partitioner.options.partition.partitionKeyProjectionField``
-     - The field name to use for a projected field that contains all the
-       fields used to partition the collection.
-       We recommend changing the value of this property only if each document already
-       contains the ``__idx`` field.
-      
-       **Default:** ``__idx``
 
 Specifying Properties in ``connection.uri``
 -------------------------------------------

--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -286,6 +286,16 @@ To use this configuration, set the ``partitioner`` configuration option to
 
        **Default:** ``10``
 
+.. example::
+
+   For a collection with 640 documents with an average document
+   size of 0.5 MB, the default ``SamplePartitioner`` configuration creates
+   5 partitions with 128 documents per partition.
+
+   The {+connector-short+} samples 50 documents (the default 10
+   per intended partition) and defines 5 partitions by selecting
+   partition field ranges from the sampled documents.
+
 .. _conf-mongoshardedpartitioner:
 .. _conf-shardedpartitioner:
 
@@ -304,16 +314,6 @@ To use this configuration, set the ``partitioner`` configuration option to
       chunk to cover all shard key values, making the sharded partitioner inefficient.
       We do not recommend using the sharded partitioner when connected to MongoDB v6.0 and later.
    2. The sharded partitioner is not compatible with hashed shard keys.
-
-.. example::
-
-   For a collection with 640 documents with an average document
-   size of 0.5 MB, the default ``SamplePartitioner`` configuration creates
-   5 partitions with 128 documents per partition.
-
-   The {+connector-short+} samples 50 documents (the default 10
-   per intended partition) and defines 5 partitions by selecting
-   partition field ranges from the sampled documents.
 
 .. _conf-mongopaginatebysizepartitioner:
 .. _conf-paginatebysizepartitioner:

--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -198,9 +198,8 @@ AutoBucketPartitioner Configuration (default)
 The ``AutoBucketPartitioner`` is the default partitioner configuration. It
 samples the data to generate partitions and uses
 the :manual:`$bucketAuto </reference/operator/aggregation/bucketAuto/>`
-aggregation stage to paginate data based on the the specified parameters. By
-using this configuration,  you can partition the data across single or multiple
-fields, including nested fields.
+aggregation stage to paginate. By using this configuration, you can partition
+the data across single or multiple fields, including nested fields.
 
 .. note:: Compound Keys
 

--- a/source/batch-mode/batch-read-config.txt
+++ b/source/batch-mode/batch-read-config.txt
@@ -249,9 +249,9 @@ To use this configuration, set the ``partitioner`` configuration option to
 SamplePartitioner Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``SamplePartitioner`` configuration configuration is similar to the
-:ref:`AutoBucketPartitioner <conf-autobucketpartitioner>`
-configuration, but does not use the ``$bucketAuto`` aggregation stage. This
+The ``SamplePartitioner`` configuration is similar to the
+:ref:`AutoBucketPartitioner <conf-autobucketpartitioner>` configuration, but
+does not use the ``$bucketAuto`` aggregation stage. This
 configuration lets you specify a partition field, partition size, and number of
 samples per partition. 
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -18,6 +18,13 @@ Release Notes
    :depth: 1
    :class: singlecol
 
+MongoDB Connector for Spark 10.5
+--------------------------------
+
+The 10.5 connector release includes the following changes and new features:
+
+- Changes the default batch read partitioner configuration to be ````AutoBucketPartitioner``
+
 MongoDB Connector for Spark 10.4
 --------------------------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -23,7 +23,7 @@ MongoDB Connector for Spark 10.5
 
 The 10.5 connector release includes the following changes and new features:
 
-- Changes the default batch read partitioner configuration to be ````AutoBucketPartitioner``
+- Changes the default batch read partitioner configuration to be ``AutoBucketPartitioner``
 
 MongoDB Connector for Spark 10.4
 --------------------------------


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-spark-connector/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-49645>

### Staging Links

<!-- start insert-links -->
<li><a href=https://deploy-preview-252--docs-spark-connector.netlify.app/batch-mode/batch-read-config>batch-mode/batch-read-config</a></li><li><a href=https://deploy-preview-252--docs-spark-connector.netlify.app/release-notes>release-notes</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [ ] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
